### PR TITLE
补充 manifest 与动画调度设计说明

### DIFF
--- a/docs/v2/设计方案/桌宠运行时与动画调度设计.md
+++ b/docs/v2/设计方案/桌宠运行时与动画调度设计.md
@@ -10,7 +10,7 @@
 - 皮肤包、Clip、Action、Recipe、ActionPool、BehaviorRule 和 Custom Interaction 的详细层级模型，以 `docs/v2/设计方案/皮肤包播放行为设计.md` 为准。
 - `docs/v2/参考资料/动画素材盘点.md` 是旧 GIF 素材盘点和迁移线索。
 
-> **当前代码状态（Phase 1 收官后）**：旧版桌宠手感主链路已经可运行。表现层是原生 `PetSurfaceWindow`，行为事件统一进入 `PetEventBridge`；`InteractionPipeline` 读取 manifest、BehaviorTrigger、BehaviorRule、Custom Interaction 和 ExpressionMapping，输出 `ActionRequest`；`PetRuntime` 执行主体动画、recipe、音效和 Prop。Phase 2 的 Go sidecar / ChatWindow 还未接入，但 `agent.expressionRequested` 到动画请求的链路已准备好。
+> **当前代码状态（Phase 2.0 合入后）**：旧版桌宠手感主链路已经可运行。表现层是原生 `PetSurfaceWindow`，行为事件统一进入 `PetEventBridge`；`InteractionPipeline` 读取 manifest、BehaviorTrigger、BehaviorRule、Custom Interaction 和 ExpressionMapping，输出 `ActionRequest`；`PetRuntime` 执行主体动画、recipe、音效和 Prop。Phase 2.0 已加入 QML `ChatWindow`、C++ `ChatController` 和 Go mock sidecar，聊天流事件会通过 `PetRuntime::requestExpression(state, expression)` 进入同一条 expression 映射链路。真实模型 provider、对话历史、人设和密钥配置仍是后续阶段。
 
 当前运行时主链路：
 
@@ -18,7 +18,9 @@
 flowchart TD
     Surface["PetSurfaceWindow<br/>鼠标、拖拽、QMovie 帧结束"]
     Menu["PetContextMenu<br/>runtime command / skin command"]
-    Agent["Agent / Chat<br/>Phase 2"]
+    Chat["ChatWindow<br/>用户输入 / 流式文本"]
+    Controller["ChatController<br/>SSE 解析 / sidecar 进程"]
+    Agent["Go sidecar<br/>Phase 2.0 mock provider"]
     Bridge["PetEventBridge<br/>封装 PetEvent + snapshot"]
     Pipeline["InteractionPipeline<br/>CI / manifest 规则 / ExpressionMappingResolver"]
     Runtime["PetRuntime"]
@@ -28,7 +30,10 @@ flowchart TD
 
     Surface --> Bridge
     Menu --> Bridge
-    Agent -. requestExpression .-> Runtime
+    Chat --> Controller
+    Controller --> Agent
+    Agent --> Controller
+    Controller -. requestExpression .-> Runtime
     Bridge --> Pipeline
     Runtime -->|idle / action.completed 等内部事件| Pipeline
     Pipeline -->|ActionRequest| Bridge
@@ -775,17 +780,23 @@ Go Core 校验模型输出：
 
 Qt Pet Runtime 根据 state、expression、当前 facing、当前 action 和 manifest 选择最终动画。
 
-Phase 1 已经具备的本地链路如下，Phase 2 只需要把 Go sidecar 的语义事件接到同一个入口：
+Phase 2.0 的本地闭环如下。当前 sidecar 仍是 mock provider，但事件边界已经按真实 provider 预留：ChatWindow 只负责 UI，ChatController 负责启动 sidecar、发送消息和解析 SSE，PetRuntime 只接收语义 expression 请求。
 
 ```mermaid
 sequenceDiagram
-    participant Core as Go sidecar / ChatWindow
+    participant UI as ChatWindow
+    participant Controller as ChatController
+    participant Core as Go sidecar
     participant Runtime as PetRuntime
     participant Pipeline as InteractionPipeline
     participant Resolver as ExpressionMappingResolver
     participant Manifest as SkinManifest
 
-    Core->>Runtime: requestExpression("speaking", "objection")
+    UI->>Controller: sendMessage(text)
+    Controller->>Core: POST /v1/chat/messages
+    Core-->>Controller: SSE expression/thinking/delta/done
+    Controller->>Runtime: requestExpression("thinking", "neutral")
+    Controller->>Runtime: requestExpression("speaking", "objection")
     Runtime->>Pipeline: PetEvent(agent.expressionRequested)
     Pipeline->>Resolver: resolve(manifest, state, expression)
     Resolver->>Manifest: expressions + expressionMappings
@@ -793,6 +804,14 @@ sequenceDiagram
     Pipeline-->>Runtime: request
     Runtime->>Runtime: submitActionRequest(request)
 ```
+
+流式输出和动画收尾的边界：
+
+- `thinking` 事件表示模型正在准备回复，通常映射到 `thinking` action。
+- `expression` / `speaking` 事件表示即将或正在输出文本，映射到 speaking 可用的 expression。
+- `delta` 只更新聊天文本，不应每个 token 都重置桌宠动画。
+- `done` 表示文本流结束，但不等于“立刻切回 idle”。如果当前 speaking action 是 `onceThenIdle`，应让当前动作自然播完；如果未来改成 phased speaking，则应在最近自然边界播放 exit 后再回 idle。
+- `cancel`、窗口关闭或 provider error 可以显式请求 idle/error，这类打断属于用户或错误事件，不属于普通 `done`。
 
 ## 10. 旧版手感还原
 
@@ -878,19 +897,27 @@ phased thinking
 降级为 neutral，不报错
 ```
 
-## 12. MVP 范围
+## 12. 当前 MVP 范围
 
-Phase 0 / 1 只实现必要能力：
+Phase 0 / 1 已实现必要桌宠运行时能力：
 
 - `loop`
 - `oneshot`
 - 左右朝向变体。
 - 8 方向移动动画。
-- `currentAction + currentRecipe + pendingRequest`。
-- `interruptHint = immediate / afterCurrent`。
+- `currentAction + currentRecipe` 的即时调度。
+- `ActionRequest::interruptHint` 字段保留；复杂 `afterCurrent` 排队尚未完整驱动。
 - 空闲随机动作。
 - 鼠标交互。
 - 检察官徽章和音效。
+
+Phase 2.0 已实现 AI 聊天最小闭环：
+
+- QML `ChatWindow` 和 Dock 激活策略。
+- C++ `ChatController` 启动并连接 Go sidecar。
+- Go mock provider 通过 SSE 输出聊天事件。
+- `thinking` / `speaking` / `error` 语义事件接入 `PetRuntime::requestExpression(...)`。
+- 流结束后不立即强制 idle，避免打断 speaking 动画自然收尾。
 
 高级能力后置：
 
@@ -899,11 +926,14 @@ Phase 0 / 1 只实现必要能力：
 - 可视化帧段校准工具。
 - 复杂跨屏寻路。
 - 完整 action sequence 编辑。
+- 真实模型 provider、历史、人设和密钥配置。
 - 完整换肤管理 UI。
 
-## 13. Phase 1 当前落地状态
+## 13. 当前落地状态与文档边界
 
-Phase 0.65 之前的拆分已经把 manifest、loader、pool selector、behavior trigger、HitZoneMatcher、SkinCommand、PropController、原生表面和窗口输入 mask 落地。当前实现与本文目标之间还有若干处偏差：v1 功能现状盘点、框架内残留的 Miles 硬编码点清单、对应的收口 Phase，统一记录在 `阶段记录/v1 手感回归与定制化接入.md`。本文不再重复，避免长期 schema 文档与时态状态混在一处。
+Phase 0.65 之前的拆分已经把 manifest、loader、pool selector、behavior trigger、HitZoneMatcher、SkinCommand、PropController、原生表面和窗口输入 mask 落地。Phase 2.0 在此基础上接入聊天窗和 mock sidecar，但没有改变 Pet Runtime 的核心职责：运行时仍只执行语义化 `ActionRequest`，不理解模型 prompt、HTTP 细节或聊天 UI 状态。
+
+当前实现与目标模型之间还有若干处偏差：v1 功能现状盘点、框架内残留的 Miles 硬编码点清单、对应的收口 Phase，统一记录在 `阶段记录/v1 手感回归与定制化接入.md`。manifest schema、字段示例和旧 GIF 拆 phase 迁移说明，以 `皮肤包播放行为设计.md` 为准；本文只解释运行时为什么这么调度。
 
 设计上需要在此说明的一点：`action.completed` follow-up 链路为：
 

--- a/docs/v2/设计方案/皮肤包播放行为设计.md
+++ b/docs/v2/设计方案/皮肤包播放行为设计.md
@@ -163,6 +163,73 @@ skins/miles-edgeworth/
 | `audio` | 语音语言与声音请求 | `AudioController` |
 | `expressions` / `expressionMappings` | Agent expression 到动作请求的映射 | `ExpressionMappingResolver` |
 
+## Manifest 字段速查
+
+当前 `schemaVersion: 3` 的可运行 Miles manifest 仍把素材、行为和高级交互配置放在同一个 `manifest.json`。读文档时可以先按下表定位：基础字段负责“这个皮肤是谁和多大”，动画字段负责“能播什么”，行为字段负责“什么事件触发什么”，扩展字段负责“语音、Prop 和高级交互”。
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `schemaVersion` | number | 是 | manifest schema 版本。当前 Miles 使用 `3`。 |
+| `id` / `name` / `version` | string / string / number | 是 | 皮肤稳定 id、显示名称和皮肤版本。 |
+| `canvas` | object | 是 | 基础窗口、动画显示和 hit zone 逻辑画布尺寸。 |
+| `defaultSize` / `sizes` | string / array | 是 | 默认尺寸档位和可选尺寸菜单。 |
+| `facings` / `defaultFacing` | array / string | 是 | 普通动作可用朝向和默认朝向。 |
+| `movementDirections` | array | 移动皮肤需要 | 移动系统可用方向，例如 8 方向行走/跑步。 |
+| `movementFacingMap` | object | 可选 | 移动方向到普通朝向的映射，例如 `east -> right`。 |
+| `states` | object | 是 | 稳定 PetState 到默认 action 的映射。 |
+| `fallbackAction` | string | 是 | action / expression 无法解析时的最终兜底 action。 |
+| `actions` | object | 是 | 语义动作定义，包含 loopMode、variants、movement 等。 |
+| `recipes` | object | 有编排时需要 | 一个请求的播放编排；可以引用 action 或声明 steps。 |
+| `actionPools` | object | 随机/候选行为需要 | 多个候选 recipe/action 的集合，按权重或顺序选择。 |
+| `behaviorTriggers` | object | idle/续接需要 | 运行时内部事件触发后的候选入口，例如启动、idle 循环、动作完成。 |
+| `behaviorRules` | array | 输入事件需要 | 外部事件到 action/recipe/pool 的声明式映射，例如拖拽晃动。 |
+| `hitZones` | object | 点击行为需要 | 鼠标点击语义区域，支持 rect 和 polygon。 |
+| `clickBehaviors` | object | 点击行为需要 | 单击/双击入口列表，把 hit zone 或 CI 映射到 pool/action/recipe。 |
+| `skinCommands` | object | 皮肤菜单需要 | 简单皮肤命令，例如 Miles 的“喂食红茶”。 |
+| `capabilities` | object | 可选 | 通用能力配置，例如 rest/sleep 入口。 |
+| `audio` | object | 有语音时需要 | 默认语音语言和可切换语言列表。 |
+| `expressions` | array | Agent/AI 需要 | 当前皮肤暴露给模型的 expression 标签说明。 |
+| `expressionMappings` | object | Agent/AI 需要 | expression 到 action/recipe 候选的映射。 |
+| `props` | object | 有临时道具时需要 | 主体外 Prop 的视觉、运动和点击/过期 recipe。 |
+| `customInteractions` | array | 高级玩法需要 | 启用哪些高级交互 handler。 |
+| `customInteractionConfig` | object | 高级玩法需要 | 每个 handler 的皮肤侧参数。 |
+
+最小可运行骨架示例：
+
+```json
+{
+  "schemaVersion": 3,
+  "id": "miles-edgeworth",
+  "name": "Miles Edgeworth",
+  "version": 1,
+  "canvas": { "windowSize": 120, "imageSize": 100, "hitZoneSize": 240, "idleLoopAction": "idle_stand" },
+  "defaultSize": "medium",
+  "sizes": [{ "id": "medium", "label": "中", "scale": 2.0 }],
+  "facings": ["right", "left"],
+  "defaultFacing": "right",
+  "states": {
+    "idle": { "action": "idle_stand" },
+    "thinking": { "action": "thinking" },
+    "speaking": { "action": "objecting" },
+    "error": { "action": "idle_stand" }
+  },
+  "fallbackAction": "idle_stand",
+  "actions": {
+    "idle_stand": {
+      "label": "站立待机",
+      "category": "idle",
+      "loopMode": "loop",
+      "variants": {
+        "right": { "animation": "skin:assets/body/idle/stand-right.gif" },
+        "left": { "animation": "skin:assets/body/idle/stand-left.gif" }
+      }
+    }
+  }
+}
+```
+
+当前实现里 `actions.*.variants.*.animation` 可以直接引用 `skin:assets/...`。长期目标模型仍保留 `clips` / `frameRange`，用于把单个 GIF 拆成 `enter`、`loop`、`exit` 片段；在运行时支持局部帧播放或 asset compiler 生成派生素材之前，`frameRange` 先作为设计和素材迁移数据记录。
+
 ## Canvas 与 Anchor
 
 每个皮肤需要声明一个逻辑画布。画布决定主体窗口的基础尺寸，也决定不同动画之间如何对齐。
@@ -288,9 +355,16 @@ Miles 当前分区沿用旧版 polygon / rect 思路即可。Phase 0.62 已接�
 - 双击列表里的每一项都是"如果可用就用它"：`customInteraction` 表示交给某个 CI 决定是否接管（CI 不接管则继续往下找）；`pool` / `recipe` / `action` 表示直接产生 ActionRequest。
 - 框架运行时不再写死 `click.upperArm → upper_arm` 这种字符串映射；所有皮肤通过 manifest 描述自己的命名。
 
-## Clip、Action 与 Recipe
+## Assets、Clip、Action 与 Recipe
 
-Clip 是素材片段，Action 是语义动作，Recipe 是播放编排。三者分开后，同一段素材可以被多个触发来源复用。
+这四层回答不同问题：
+
+| 层级 | 回答的问题 | 当前实现状态 |
+| --- | --- | --- |
+| Assets | 文件在哪里 | 已使用 `skin:assets/...` URL |
+| Clip | 从文件取哪一段 | 目标 schema；当前主要作为拆 GIF 的设计记录 |
+| Action | 这个动作是什么意思 | 已由 `actions` 落地 |
+| Recipe | 这次请求怎样编排播放 | 已由 `recipes` 和 `steps` 落地 |
 
 ```mermaid
 flowchart LR
@@ -299,7 +373,7 @@ flowchart LR
     ClipC["clip: thinking.exit"]
     Action["action: thinking"]
     RecipeIdle["recipe: idle.randomThinking"]
-    RecipeAgent["recipe: agent.thinking"]
+    RecipeAgent["recipe: thinking.holdUntilCancelled"]
 
     ClipA --> Action
     ClipB --> Action
@@ -308,30 +382,187 @@ flowchart LR
     Action --> RecipeAgent
 ```
 
-示例：
+### Assets 与 Clip
+
+Assets 是皮肤包中的正本素材。它们只回答“文件在哪里”，不回答“什么时候播放”。推荐路径示例：
+
+```text
+assets/body/idle/stand-right.gif
+assets/body/gestures/thinking-right.gif
+assets/body/locomotion/walk-east.gif
+assets/props/prosecutor_badge/prosecutor-badge.png
+assets/audio/voice/jp/takethat.wav
+```
+
+Clip 是最小可复用播放片段，只描述“从哪个素材取哪一段”。当前 Qt 播放路径尚未直接支持 GIF 局部帧段，因此 Miles manifest 先在 `actions.*.variants.*.animation` 中直接引用完整 GIF；需要拆 phase 的素材先在 `动画素材盘点.md` 记录帧段，后续再转成 `clips` 或派生文件。
+
+目标 `clips` 字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `file` | string | 原始素材或派生素材路径，推荐 `skin:assets/...` 或皮肤内相对路径。 |
+| `frameRange` | `[start, end]` | 可选，闭区间帧段。素材盘点中使用 1-based 帧号，导出工具需要统一转换规则。 |
+| `durationMs` | number | 可选，单帧 hold 或派生素材的目标时长。 |
+| `loop` | boolean | 可选，该 clip 是否天然可循环。 |
+| `anchorOffset` | object | 可选，修正局部片段的锚点偏移。 |
+| `generatedFrom` | object | 可选，记录派生 clip 的来源和导出参数。 |
+
+目标示例：
+
+```json
+{
+  "clips": {
+    "thinking_enter_right": {
+      "file": "skin:assets/body/gestures/thinking-right.gif",
+      "frameRange": [1, 4]
+    },
+    "thinking_loop_right": {
+      "file": "skin:assets/body/gestures/thinking-right.gif",
+      "frameRange": [5, 8],
+      "loop": true
+    },
+    "thinking_exit_right": {
+      "file": "skin:assets/body/gestures/thinking-right.gif",
+      "frameRange": [44, 47]
+    }
+  }
+}
+```
+
+如果运行时不能直接播放 `frameRange`，asset compiler 可以生成派生素材：
+
+```text
+skin:assets/body/gestures/thinking-right.gif + frameRange [5, 8]
+=> generated/clips/thinking-loop-right.webp
+```
+
+### Action
+
+Action 是有语义的动作单元。外部模块请求 `thinking`、`objecting`、`walk` 这类 action，不直接引用 GIF 文件名。
+
+字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `label` | string | 给人看的名称，用于调试、编辑器和文档。 |
+| `category` | string | 动作类别，例如 `idle`、`gesture`、`locomotion`、`cognitive`、`rest`。 |
+| `tags` | string[] | 检索和 expression 映射用标签。 |
+| `priority` | number | 默认优先级，可被 ActionRequest 覆盖。 |
+| `loopMode` | string | 单段动作播放模式：`loop`、`once`、`onceThenIdle`、`hold` 等。 |
+| `variants` | object | 朝向或移动方向变体。当前变体直接写 `animation`。 |
+| `movement` | object | 可选，移动动作每帧或每周期的窗口位移参数，写在 variant 内。 |
+| `phases` | object | 目标模型，多阶段动作定义。 |
+| `initialPhase` / `exitPhase` | string | 目标模型，多阶段动作入口和退出阶段。 |
+| `fallbackAction` | string | 可选，当前 action 不可用时的兜底 action。 |
+
+当前可运行的单段动作示例：
 
 ```json
 {
   "actions": {
-    "thinking": {
+    "objecting": {
+      "label": "异议",
       "category": "gesture",
-      "initialPhase": "enter",
-      "exitPhase": "exit",
-      "phases": {
-        "enter": { "clip": "thinking.enter", "loopMode": "once", "nextPhase": "loop" },
-        "loop": { "clip": "thinking.loop", "loopMode": "loop" },
-        "exit": { "clip": "thinking.exit", "loopMode": "onceThenIdle" }
+      "loopMode": "onceThenIdle",
+      "priority": 40,
+      "tags": ["objecting", "speaking", "emphasis"],
+      "variants": {
+        "right": { "animation": "skin:assets/body/interaction/objecting-right.gif" },
+        "left": { "animation": "skin:assets/body/interaction/objecting-left.gif" }
       }
     }
   }
 }
 ```
 
-已有素材如果只有完整 GIF，可以先把它作为单个 phase 使用。后续再用 frameRange 或派生素材拆成 enter / loop / exit。
+当前可运行的移动动作示例：
+
+```json
+{
+  "actions": {
+    "walk": {
+      "label": "走路",
+      "category": "locomotion",
+      "loopMode": "onceThenIdle",
+      "variants": {
+        "east": {
+          "animation": "skin:assets/body/locomotion/walk-east.gif",
+          "movement": { "dx": 8.4, "dy": 0 }
+        },
+        "west": {
+          "animation": "skin:assets/body/locomotion/walk-west.gif",
+          "movement": { "dx": -8.4, "dy": 0 }
+        }
+      }
+    }
+  }
+}
+```
+
+目标多阶段动作示例：
+
+```json
+{
+  "actions": {
+    "thinking": {
+      "label": "抱胸思考",
+      "category": "cognitive",
+      "initialPhase": "enter",
+      "exitPhase": "exit",
+      "phases": {
+        "enter": {
+          "loopMode": "once",
+          "variants": {
+            "right": { "clip": "thinking_enter_right" },
+            "left": { "clip": "thinking_enter_left" }
+          }
+        },
+        "loop": {
+          "loopMode": "loop",
+          "variants": {
+            "right": { "clip": "thinking_loop_right" },
+            "left": { "clip": "thinking_loop_left" }
+          }
+        },
+        "exit": {
+          "loopMode": "onceThenIdle",
+          "variants": {
+            "right": { "clip": "thinking_exit_right" },
+            "left": { "clip": "thinking_exit_left" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+常见 phase：
+
+| Phase | 用途 |
+| --- | --- |
+| `main` | 单段动作主体。 |
+| `enter` | 进入姿态，例如抬手抱胸。 |
+| `loop` | 可循环保持段，例如抱胸思考或说话口型。 |
+| `hold` | 保持某一帧或某个姿态。 |
+| `exit` | 离开姿态，例如放下双臂。 |
+| `recover` | 被打断或特殊状态恢复。 |
 
 ## Recipe 编排
 
 Recipe 建立在 action 或 clip 之上，用来表达一次播放请求的时间线。短 recipe 可以直接引用 action；复杂 recipe 可以组合多个步骤。
+
+字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `label` | string | 给人看的名称。 |
+| `scope` | string | 用途范围，例如 `idle`、`locomotion`、`interaction`、`startup`、`state`。 |
+| `action` | string | 直接绑定一个 action。 |
+| `movementDirection` | string | 可选，移动 recipe 指定方向；`$current` 表示使用当前方向。 |
+| `steps` | array | 时间线步骤，可顺序播放多个 action 或 recipe。 |
+| `params` | object | 目标模型，声明运行时参数。 |
+| `autoReturn` | string | 目标模型，结束后返回的 action 或 state。 |
 
 ```json
 {
@@ -340,7 +571,7 @@ Recipe 建立在 action 或 clip 之上，用来表达一次播放请求的时�
       "action": "idle_thinking_once",
       "scope": "idle"
     },
-    "agent.thinking": {
+    "thinking.holdUntilCancelled": {
       "steps": [
         { "action": "thinking", "phase": "enter" },
         { "action": "thinking", "phase": "loop", "duration": "runtime" },
@@ -352,11 +583,65 @@ Recipe 建立在 action 或 clip 之上，用来表达一次播放请求的时�
 }
 ```
 
-运行时可为 recipe 提供动态参数，例如循环时长、循环次数或提前退出信号。manifest 负责声明 recipe 支持哪些参数，具体值由运行时请求传入。
+当前可运行 recipe 主要有两种形态：
+
+```json
+{
+  "recipes": {
+    "walk.current": {
+      "label": "沿当前方向继续走",
+      "scope": "locomotion",
+      "action": "walk",
+      "movementDirection": "$current"
+    },
+    "startup.briefcase": {
+      "label": "公文包启动入场",
+      "scope": "startup",
+      "steps": [
+        { "action": "briefcase_in" },
+        { "action": "briefcase_stop" },
+        { "action": "idle_stand" }
+      ]
+    }
+  }
+}
+```
+
+目标模型中，运行时可为 recipe 提供动态参数，例如循环时长、循环次数或提前退出信号。manifest 负责声明 recipe 支持哪些参数，具体值由运行时请求传入。
+
+```json
+{
+  "recipes": {
+    "tea.loopForDuration": {
+      "scope": "state",
+      "action": "tea",
+      "params": {
+        "durationMs": { "type": "number", "default": 5000, "min": 1000, "max": 30000 }
+      },
+      "steps": [
+        { "phase": "loop", "durationMs": { "param": "durationMs" } }
+      ]
+    }
+  }
+}
+```
 
 ## ActionPool
 
 ActionPool 用于“从多个候选里选择一个”。它可以被 idle、点击、双击、菜单、LLM 表达标签复用。
+
+字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `label` | string | 给人看的名称。 |
+| `entries` | array | 候选列表。 |
+| `entries[].action` | string | 直接候选 action id。 |
+| `entries[].recipe` | string | 候选 recipe id；当前 Miles 主要使用 recipe。 |
+| `entries[].pool` | string | 候选可以继续引用另一个 pool；需要避免循环引用。 |
+| `entries[].weight` | number | 随机权重，必须为正数。 |
+| `entries[].when` | object | 可选，候选级过滤条件。 |
+| `entries[].cooldownMs` | number | 目标模型，避免短时间重复。 |
 
 ```json
 {
@@ -378,36 +663,197 @@ ActionPool 用于“从多个候选里选择一个”。它可以被 idle、点�
 }
 ```
 
+选择策略通常由调用方决定：`ActionPoolSelector` 当前按权重选候选；`ExpressionMappingResolver` 支持 `first_available` 和 `weighted_random`。后续如果给 pool 本身增加 `selection`，需要同步更新静态校验。
+
 LLM 不应被要求从项目内置固定词表中选择。可选 expression/action 标签来自当前皮肤配置。模型侧只看到当前皮肤暴露的标签说明和约束。
 
-## BehaviorRule
+## Expression 与 ExpressionMapping
 
-BehaviorRule 把通用事件映射到 ActionPool 或 Recipe。
+`expressions` 是暴露给 Agent/LLM 的标签清单，`expressionMappings` 决定标签如何落到 action 或 recipe。模型只能选择 expression，不选择 GIF、旧版数字文件名或具体 action。
+
+Expression 字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | string | 稳定标签 id，例如 `neutral`、`objection`、`polite`。 |
+| `label` | string | 给人看的名称，也可进入调试 UI。 |
+| `description` | string | 给模型和皮肤作者看的语义说明。 |
+| `allowedStates` | string[] | 该 expression 允许用于哪些 PetState。 |
+| `priority` | number | 多个表达候选并存时的默认优先级。 |
+
+ExpressionMapping 字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `selection` | string | `first_available` 或 `weighted_random`。 |
+| `fallback` | string | 该 expression 无可用候选时回退到哪个 expression。 |
+| `actions` | array | 候选列表；名字沿用当前实现，条目可写 `action` 或 `recipe`。 |
+| `actions[].action` | string | 候选 action id。 |
+| `actions[].recipe` | string | 候选 recipe id。 |
+| `actions[].weight` | number | `weighted_random` 时使用。 |
+| `actions[].allowedStates` | string[] | 候选级状态过滤。 |
+
+示例：
+
+```json
+{
+  "expressions": [
+    {
+      "id": "objection",
+      "label": "异议",
+      "description": "强烈反驳、指出漏洞、语气锐利时使用",
+      "allowedStates": ["speaking"],
+      "priority": 90
+    }
+  ],
+  "expressionMappings": {
+    "objection": {
+      "selection": "weighted_random",
+      "fallback": "neutral",
+      "actions": [
+        { "action": "objecting", "weight": 3, "allowedStates": ["speaking"] },
+        { "recipe": "doubleClick.holdIt", "weight": 1, "allowedStates": ["speaking"] }
+      ]
+    }
+  }
+}
+```
+
+## BehaviorTrigger 与 BehaviorRule
+
+`behaviorTriggers` 处理运行时内部事件的后续调度，例如启动后入场、idle 循环结束、动作完成后的续接。`behaviorRules` 处理外部输入或确定性事件，例如拖拽晃动和拖拽释放。二者都会生成 ActionRequest，但来源不同。
+
+BehaviorTrigger 字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `label` | string | 给人看的名称。 |
+| `when` | object | 可选，触发条件，例如当前 state/action、是否无活跃 recipe。 |
+| `entries` | array | 候选入口。 |
+| `entries[].type` | string | `pool`、`recipe`、`action` 或 `none`。 |
+| `entries[].pool` / `recipe` / `action` | string | 入口 id，随 `type` 选择。 |
+| `entries[].weight` | number | 候选权重。 |
+| `entries[].when` | object | 候选级触发条件。 |
+
+当前示例：
+
+```json
+{
+  "behaviorTriggers": {
+    "idle.loopFinished": {
+      "label": "站立循环完成后的待机调度",
+      "when": {
+        "state": "idle",
+        "action": "idle_stand",
+        "requiresNoActiveRecipe": true
+      },
+      "entries": [
+        { "type": "pool", "pool": "idle.random", "weight": 70 },
+        { "type": "none", "weight": 30 }
+      ]
+    }
+  }
+}
+```
+
+BehaviorRule 字段建议：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `event` | string | 事件名，例如 `pointer.dragShake`、`pointer.dragReleased`。 |
+| `when` | object | 可选，状态、当前 action、hold 是否完成等条件。 |
+| `action` | string | 直接请求 action。 |
+| `recipe` | string | 直接请求 recipe。 |
+| `pool` | string | 从 action pool 中选择。 |
+| `expression` | string | 目标模型，请求 expression mapping。 |
+| `priority` | number | 目标模型，请求优先级。 |
+| `interruptHint` | string | 请求切换提示，当前结构保留，复杂排队后续实现。 |
+| `sideEffects` | array | 目标模型，气泡、音效等副作用。 |
 
 ```json
 {
   "behaviorRules": [
     {
-      "event": "idle.loopFinished",
-      "when": { "state": "idle", "action": "idle_stand" },
-      "pool": "idle.random",
-      "probability": 0.7
+      "event": "pointer.dragShake",
+      "action": "drag_crouch"
     },
     {
-      "event": "pointer.singleClick",
-      "hitZone": "head",
-      "pool": "click.head"
-    },
-    {
-      "event": "agent.stateChanged",
-      "state": "thinking",
-      "recipe": "agent.thinking"
+      "event": "pointer.dragReleased",
+      "when": { "action": "drag_crouch", "holdCompleted": true },
+      "action": "drag_stand_up_full"
     }
   ]
 }
 ```
 
+推荐事件命名：
+
+| 事件 | 用途 |
+| --- | --- |
+| `runtime.started` | 桌宠运行时启动。 |
+| `idle.loopFinished` | idle loop action 播完一个循环。 |
+| `action.completed` | 某个 action 自然结束。 |
+| `pointer.singleClick` | 单击，由 `clickBehaviors` 优先处理。 |
+| `pointer.doubleClick` | 双击，可先交给 Custom Interaction。 |
+| `pointer.dragShake` / `pointer.dragReleased` | 拖拽晃动和释放。 |
+| `menu.command` | 右键菜单命令。 |
+| `agent.expressionRequested` | Agent/Chat 请求表达标签。 |
+| `prop.clicked` / `prop.expired` | 道具点击或生命周期结束。 |
+
 这些规则属于普通换肤能力。它们应尽量保持声明式，便于编辑器、预览器和校验工具理解。
+
+## State、Capability、Fallback 与移动映射
+
+`states` 描述程序稳定状态默认对应哪个 action。它不是完整状态机，只是运行时缺少更具体请求时的默认动作表。
+
+```json
+{
+  "states": {
+    "idle": { "action": "idle_stand" },
+    "thinking": { "action": "thinking" },
+    "speaking": { "action": "objecting" },
+    "error": { "action": "idle_stand" }
+  },
+  "fallbackAction": "idle_stand"
+}
+```
+
+字段说明：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `states.<state>.action` | string | 该 PetState 的默认 action。 |
+| `fallbackAction` | string | action、recipe、expression 都无法解析时的最终兜底。 |
+
+`capabilities` 用来声明框架通用能力的皮肤侧入口。例子：
+
+```json
+{
+  "capabilities": {
+    "rest": {
+      "enterRecipe": "sleep.enterLoopExit",
+      "loopAction": "sleep"
+    }
+  }
+}
+```
+
+`rest.enterRecipe` 表示从清醒进入休息时播放哪个 recipe；`rest.loopAction` 表示睡眠保持态使用哪个 action。通用能力的菜单、状态切换和权限逻辑由框架提供，皮肤只声明素材入口。
+
+`movementFacingMap` 用来把移动方向折算成普通朝向。移动动画可以有 8 方向，但说话、点击、待机通常只有左右朝向；运行时需要用这张表决定移动结束后角色面朝哪里。
+
+```json
+{
+  "movementFacingMap": {
+    "east": "right",
+    "northEast": "right",
+    "southEast": "right",
+    "west": "left",
+    "northWest": "left",
+    "southWest": "left"
+  }
+}
+```
 
 ## 通用能力、皮肤定制命令与 Custom Interaction
 
@@ -441,6 +887,36 @@ flowchart TD
 - 检察官徽章当前使用 manifest prop 和 `PropController` 管理视觉生命周期；更复杂的触发条件、概率分支和额外副作用可以进入 Custom Interaction。
 - 语音语言属于可选 Audio Capability，不应假设所有皮肤都有语音。
 
+### Skin Command
+
+`skinCommands` 是皮肤自己的简单菜单命令。它适合“菜单点一下 -> 发一个 action/recipe/pool 请求”的场景；如果需要概率、跨事件状态、动态 Prop 或计时器，应放进 Custom Interaction。
+
+```json
+{
+  "skinCommands": {
+    "miles.feedTea": {
+      "label": "喂食红茶",
+      "enabledWhen": {
+        "notAction": "sleep"
+      },
+      "request": {
+        "type": "pool",
+        "pool": "menu.tea"
+      }
+    }
+  }
+}
+```
+
+字段说明：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `label` | string | 菜单显示文本。 |
+| `enabledWhen` | object | 可选，菜单可用条件；当前常用 `notAction`。 |
+| `request.type` | string | `pool`、`recipe` 或 `action`。 |
+| `request.pool` / `recipe` / `action` | string | 请求目标 id，随 `request.type` 选择。 |
+
 ### Audio Capability
 
 语音能力由 `manifest.audio` 声明。未声明 `voiceLanguages` 的皮肤仍可以播放普通 `sound`，但右键菜单不会出现语音切换入口；声明后，菜单按 `id / label` 动态生成语言项。
@@ -459,6 +935,55 @@ flowchart TD
 ```
 
 `AudioController` 持有当前语言、静音状态和当前播放请求。`PetRuntime` 只暴露 `currentAudioLanguageId`、`availableAudioLanguages` 和 `setAudioLanguage(...)` 这类通用入口，不写死任何具体语言。双击候选池的语言后缀覆盖继续沿用 `doubleClick.random.<languageId>`，由当前语言决定是否选择覆盖池。
+
+### Prop
+
+`props` 描述主体窗口外的临时道具，例如检察官徽章、掉落物、漂浮表情。Prop 的生命周期由 `PropController` 管理；主体动作只通过 recipe 或 Custom Interaction 请求生成、点击或过期后再回到事件管线。
+
+```json
+{
+  "props": {
+    "prosecutor_badge": {
+      "asset": "skin:assets/props/prosecutor_badge/prosecutor-badge.png",
+      "width": 94,
+      "height": 94,
+      "visualWidth": 24,
+      "visualHeight": 24,
+      "delayMs": 700,
+      "durationMs": 1500,
+      "clickedRecipe": "bow.once",
+      "expiredRecipe": "pickup.once",
+      "startOffsets": {
+        "right": { "x": 172, "y": 32 },
+        "left": { "x": 2, "y": 32 }
+      },
+      "travelBase": {
+        "right": { "x": 600, "y": 0 },
+        "left": { "x": -600, "y": 0 }
+      },
+      "travelPerScale": {
+        "right": { "x": 150, "y": 0 },
+        "left": { "x": -150, "y": 0 }
+      }
+    }
+  }
+}
+```
+
+字段说明：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `asset` | string | Prop 图片路径。 |
+| `width` / `height` | number | 素材原始或逻辑尺寸。 |
+| `visualWidth` / `visualHeight` | number | 屏幕显示尺寸，按桌宠 scale 参与换算。 |
+| `delayMs` | number | 请求后延迟多久生成。 |
+| `durationMs` | number | 未被点击时存活多久。 |
+| `clickedRecipe` | string | Prop 被点击后触发的 recipe。 |
+| `expiredRecipe` | string | Prop 自然过期后触发的 recipe。 |
+| `startOffsets` | object | 不同朝向下相对主体窗口的起点。 |
+| `travel` | object | 固定飞行位移；旧字段，能满足时优先用下面两个 scale-aware 字段。 |
+| `travelBase` / `travelPerScale` | object | 按当前尺寸计算飞行位移，避免大尺寸和小尺寸手感不一致。 |
 
 ## Custom Interaction
 
@@ -673,6 +1198,128 @@ CustomInteractionOutcome ProsecutorBadgeInteraction::handleEvent(
 
 这个 CI 不引用 `PetRuntime` / `PropController`、不读写其它 handler 的状态，也不依赖 Miles 之外的常量；同样的 handler 可以被另一个皮肤通过改 manifest config 复用。
 
+## 从素材盘点到 Manifest 的迁移例子
+
+`动画素材盘点.md` 记录的是旧 GIF 事实；本节说明这些事实未来如何沉淀成 manifest。当前运行时还没直接播放 `clips.frameRange`，因此下面示例属于目标 schema：短期可以先把这些帧段保留在素材盘点和设计文档里，等 asset compiler 或局部帧播放器落地后再迁入 manifest。
+
+### 抱胸思考：thinking
+
+素材盘点记录：
+
+```text
+thinking-right/left.gif
+1-4 帧：enter
+5-8 帧：loop
+44-47 帧：exit
+```
+
+目标配置片段：
+
+```json
+{
+  "clips": {
+    "thinking_enter_right": { "file": "skin:assets/body/gestures/thinking-right.gif", "frameRange": [1, 4] },
+    "thinking_loop_right": { "file": "skin:assets/body/gestures/thinking-right.gif", "frameRange": [5, 8], "loop": true },
+    "thinking_exit_right": { "file": "skin:assets/body/gestures/thinking-right.gif", "frameRange": [44, 47] }
+  },
+  "actions": {
+    "thinking": {
+      "label": "抱胸思考",
+      "initialPhase": "enter",
+      "exitPhase": "exit",
+      "phases": {
+        "enter": { "variants": { "right": { "clip": "thinking_enter_right" } } },
+        "loop": { "loopMode": "loop", "variants": { "right": { "clip": "thinking_loop_right" } } },
+        "exit": { "variants": { "right": { "clip": "thinking_exit_right" } } }
+      }
+    }
+  },
+  "recipes": {
+    "thinking.holdUntilCancelled": {
+      "scope": "state",
+      "action": "thinking",
+      "steps": [
+        { "phase": "enter" },
+        { "phase": "loop", "repeat": "untilCancelled" },
+        { "phase": "exit" }
+      ]
+    }
+  }
+}
+```
+
+这个 recipe 适合 AI `thinking`：开始请求时 enter，等待模型时 loop，取消或进入 speaking 前播放 exit。
+
+### 指点：pointing
+
+素材盘点记录：
+
+```text
+pointing-right/left.gif
+1-3 帧：enter
+4-7 帧：loop
+23-24 帧：exit
+```
+
+迁移方式和 `thinking` 相同。它可以有两个 recipe：`idle.pointing` 短循环几次后 exit；`speaking.pointing` 在模型连续输出时 loop，输出结束后 exit。不要把它拆成两个 action，否则 idle 和 speaking 会复制同一份素材语义。
+
+### 后撤警惕：back_away
+
+素材盘点记录：
+
+```text
+back-right/left.gif
+1-7 帧：enter
+第 7 帧：hold 点
+8-9 帧：exit
+```
+
+目标配置可以增加 `hold` phase：
+
+```json
+{
+  "actions": {
+    "back_away": {
+      "label": "后撤警惕",
+      "initialPhase": "enter",
+      "exitPhase": "exit",
+      "phases": {
+        "enter": { "variants": { "right": { "clip": "back_enter_right" } } },
+        "hold": { "loopMode": "hold", "variants": { "right": { "clip": "back_hold_right" } } },
+        "exit": { "variants": { "right": { "clip": "back_exit_right" } } }
+      }
+    }
+  }
+}
+```
+
+这个动作适合 AI 聊天中的防御、惊讶或等待用户继续输入：进入后停在 hold，明确结束时走 exit。
+
+### 抱胸说话：crossed
+
+素材盘点记录：
+
+```text
+crossed-left.gif
+1-4 帧：enter
+5-8 帧：loop / speaking / hold
+9-11 帧：exit
+```
+
+`crossed` 和 `thinking` 的区别是 loop 语义更接近 speaking。未来可以把 `expressionMappings.neutral` 或 `expressionMappings.polite` 在 `speaking` 状态下映射到 `crossed.sayUntilStreamEnds`，让聊天流输出期间保持说话循环，流结束后播放 exit。
+
+### 红茶：tea / tea_alt
+
+素材盘点记录：
+
+```text
+tea-right/left.gif、tea-alt-right/left.gif
+1-13 帧：喝茶循环 phase
+后续帧：收尾和 bow-like 致意
+```
+
+当前 `tea.once` 已能作为菜单一次性动作使用。目标 schema 可把前 13 帧拆为 `tea.loop`，用于“坐下喝茶直到用户关闭休息状态”；菜单命令仍可以使用 `tea.drinkThenBow` 这类 sequence recipe，先喝茶若干循环，再播放收尾。
+
 ## ActionRequest
 
 ActionRequest 是运行时播放请求的统一形态。
@@ -680,13 +1327,33 @@ ActionRequest 是运行时播放请求的统一形态。
 ```json
 {
   "source": "agent",
-  "recipe": "agent.thinking",
-  "interruptHint": "immediate",
-  "params": {
+  "state": "thinking",
+  "expression": "neutral",
+  "recipe": "thinking.holdUntilCancelled",
+  "recipeParams": {
     "loopDurationMs": 5000
-  }
+  },
+  "interruptHint": "immediate",
+  "priority": 70,
+  "expiresInMs": 2000
 }
 ```
+
+字段说明：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `source` | string | 请求来源，例如 `behavior`、`chat`、`agent`、`menu`、`customInteraction`。 |
+| `state` | string | 可选，目标 PetState，例如 `thinking`、`speaking`、`idle`。 |
+| `expression` | string | 可选，目标 expression 标签，由 `expressionMappings` 解析。 |
+| `action` | string | 可选，直接请求某个 action。 |
+| `recipe` | string | 可选，直接请求某个 recipe。 |
+| `pool` | string | 可选，从某个 action pool 中选择。 |
+| `recipeParams` | object | 可选，recipe 运行时参数。 |
+| `priority` | number | 可选，调度优先级。 |
+| `interruptHint` | string | 可选，新请求希望如何切换当前动作。 |
+| `expiresInMs` | number | 可选，请求过期时间。 |
+| `sideEffects` | array | 可选，气泡、音效等副作用；当前大多由 recipe/CI/Prop 路径承担。 |
 
 `interruptHint` 保持简单：
 
@@ -699,9 +1366,9 @@ ActionRequest 是运行时播放请求的统一形态。
 
 ## 表现层与 C++ 调度边界
 
-**当前实现**：桌宠本体使用原生 `PetSurfaceWindow`（QWidget），不加载 QML。`PetWindow.qml` 保留在 `qml/` 目录仅作历史参考，不参与运行。`ChatWindow` / `DashboardWindow` 将来仍计划使用 QML，届时本节约束同样适用。
+**当前实现**：桌宠本体使用原生 `PetSurfaceWindow`（QWidget），不加载 QML。`PetWindow.qml` 保留在 `qml/` 目录仅作历史参考，不参与运行。Phase 2.0 的聊天窗使用 QML `ChatWindow`，但聊天窗仍只通过 `ChatController` 发语义请求，不直接选择皮肤 GIF。
 
-表现层（现为 `PetSurfaceWindow`，未来 ChatWindow 为 QML）负责显示和输入：
+表现层（`PetSurfaceWindow` 和 `ChatWindow`）负责显示和输入：
 
 - 显示当前动画、气泡、菜单和 Prop 窗口。
 - 把点击、双击、拖拽、菜单命令转给 `PetEventBridge`。


### PR DESCRIPTION
## 变更摘要

- 为 `皮肤包播放行为设计.md` 补充 `schemaVersion: 3` manifest 顶层字段速查表、最小骨架示例，以及 ActionRequest 字段说明。
- 恢复并扩展 Clip、Action、Recipe、ActionPool、ExpressionMapping、BehaviorTrigger、BehaviorRule、State、Capability、SkinCommand、Prop、Custom Interaction 等字段说明和 JSON 示例。
- 增加从素材盘点迁移到 manifest 的例子，覆盖 `thinking`、`pointing`、`back_away`、`crossed`、`tea / tea_alt` 的 enter/loop/hold/exit 拆分线索。
- 更新 `桌宠运行时与动画调度设计.md` 的 Phase 2.0 当前状态，说明 ChatWindow、ChatController、Go mock sidecar、expression 请求链路，以及流结束不打断 speaking 动画的调度边界。

## 验证

- `git diff --check`
- Markdown 代码围栏数量检查：两篇文档均为偶数
- 过时表述检索：未发现 “Phase 2 未接入” 等旧表述残留
- `ctest --test-dir build -R check_phase_2_0_ai_chat_mvp --output-on-failure`

## 说明

- 本 PR 只修设计文档，不改运行时代码或 manifest 实现。
- `clips.frameRange` 仍标注为目标 schema；当前运行时仍以完整 GIF / `animation` URL 为主。