### PR TITLE
修复聊天结束时提前切回待机

### DIFF
--- a/apps/agent-core/internal/api/server_test.go
+++ b/apps/agent-core/internal/api/server_test.go
@@ -78,6 +78,9 @@ func TestMockChatStream(t *testing.T) {
 			t.Fatalf("stream missing %s in:\n%s", token, body)
 		}
 	}
+	if strings.Contains(body, `"state":"idle"`) {
+		t.Fatalf("normal chat completion must not request idle expression; stream was:\n%s", body)
+	}
 }
 
 func TestChatStreamRejectsEmptyMessage(t *testing.T) {

--- a/apps/agent-core/internal/chat/mock_provider.go
+++ b/apps/agent-core/internal/chat/mock_provider.go
@@ -77,17 +77,6 @@ func (p *MockProvider) StreamReply(ctx context.Context, req Request) (<-chan Str
 		}) {
 			return
 		}
-		if !send(ctx, events, p.delay, StreamEvent{
-			Type:  "CUSTOM",
-			Name:  "miles.pet.expression.requested",
-			RunID: runID,
-			Value: map[string]any{
-				"state":      "idle",
-				"expression": "neutral",
-			},
-		}) {
-			return
-		}
 		send(ctx, events, p.delay, StreamEvent{Type: "RUN_FINISHED", RunID: runID})
 	}()
 


### PR DESCRIPTION
## 变更摘要

- 移除 mock sidecar 在正常回复结束后额外发送的 `state=idle / expression=neutral` 事件。
- 增加 API 流测试，确保正常聊天完成不会请求 idle 表达，避免打断 speaking / objecting 动画自然收尾。

## 根因

`RUN_FINISHED` 本身没有切回 idle，但 mock provider 在 `TEXT_MESSAGE_END` 后、`RUN_FINISHED` 前发送了一条 idle expression。桌面端按语义请求执行，导致消息输出结束时立即切到 `idle_stand`。

## 验证

- 先运行 `go test ./internal/api -run TestMockChatStream -count=1`，确认新增测试在修复前失败并打印出 `state=idle` 事件。
- `go test ./...`
- `cmake --build build`
- `ctest --test-dir build -R 'check_phase_2_0_ai_chat_mvp|chat_controller_smoke' --output-on-failure`
- `ctest --test-dir build --output-on-failure`：73/73 通过
- 使用构建后的 `miles-agent` 本地请求 `/v1/chat/messages`，确认 SSE 中 `TEXT_MESSAGE_END` 后直接是 `RUN_FINISHED`，没有 `state=idle`。