### PR TITLE
支持聊天表达 afterCurrent 切换

### DIFF
--- a/apps/agent-core/internal/api/server_test.go
+++ b/apps/agent-core/internal/api/server_test.go
@@ -72,14 +72,13 @@ func TestMockChatStream(t *testing.T) {
 		`"expression":"objection"`,
 		`"type":"TEXT_MESSAGE_CONTENT"`,
 		`"type":"TEXT_MESSAGE_END"`,
+		`"state":"idle"`,
+		`"interruptHint":"afterCurrent"`,
 		`"type":"RUN_FINISHED"`,
 	} {
 		if !strings.Contains(body, token) {
 			t.Fatalf("stream missing %s in:\n%s", token, body)
 		}
-	}
-	if strings.Contains(body, `"state":"idle"`) {
-		t.Fatalf("normal chat completion must not request idle expression; stream was:\n%s", body)
 	}
 }
 

--- a/apps/agent-core/internal/chat/mock_provider.go
+++ b/apps/agent-core/internal/chat/mock_provider.go
@@ -77,6 +77,18 @@ func (p *MockProvider) StreamReply(ctx context.Context, req Request) (<-chan Str
 		}) {
 			return
 		}
+		if !send(ctx, events, p.delay, StreamEvent{
+			Type:  "CUSTOM",
+			Name:  "miles.pet.expression.requested",
+			RunID: runID,
+			Value: map[string]any{
+				"state":         "idle",
+				"expression":    "neutral",
+				"interruptHint": "afterCurrent",
+			},
+		}) {
+			return
+		}
 		send(ctx, events, p.delay, StreamEvent{Type: "RUN_FINISHED", RunID: runID})
 	}()
 

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -15,6 +15,15 @@ namespace {
 constexpr auto kHealthUrl = "http://127.0.0.1:39710/health";
 constexpr auto kChatMessagesUrl = "http://127.0.0.1:39710/v1/chat/messages";
 constexpr auto kExpressionRequestedEvent = "miles.pet.expression.requested";
+
+InterruptHint interruptHintFromValue(const QVariantMap &value)
+{
+    if (value.value(QStringLiteral("interruptHint")).toString() == QStringLiteral("afterCurrent")) {
+        return InterruptHint::AfterCurrent;
+    }
+
+    return InterruptHint::Immediate;
+}
 } // namespace
 
 ChatController::ChatController(PetRuntime *runtime, QObject *parent)
@@ -220,7 +229,8 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
 
     if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
         requestPetExpression(event.value.value(QStringLiteral("state")).toString(),
-                             event.value.value(QStringLiteral("expression")).toString());
+                             event.value.value(QStringLiteral("expression")).toString(),
+                             interruptHintFromValue(event.value));
     }
 }
 
@@ -288,7 +298,7 @@ void ChatController::setStatusText(const QString &statusText)
     emit statusTextChanged();
 }
 
-void ChatController::requestPetExpression(const QString &state, const QString &expression)
+void ChatController::requestPetExpression(const QString &state, const QString &expression, InterruptHint interruptHint)
 {
     if (m_runtime == nullptr) {
         return;
@@ -296,7 +306,7 @@ void ChatController::requestPetExpression(const QString &state, const QString &e
 
     const QString nextState = state.trimmed().isEmpty() ? QStringLiteral("idle") : state.trimmed();
     const QString nextExpression = expression.trimmed().isEmpty() ? QStringLiteral("neutral") : expression.trimmed();
-    m_runtime->requestExpression(nextState, nextExpression);
+    m_runtime->requestExpression(nextState, nextExpression, interruptHint);
 }
 
 QString ChatController::sidecarExecutablePath() const

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "chat/ChatStreamEvent.h"
+#include "pet/requests/ActionRequest.h"
 
 #include <QJSEngine>
 #include <QList>
@@ -55,7 +56,11 @@ private:
     void setSidecarReady(bool ready);
     void setSending(bool sending);
     void setStatusText(const QString &statusText);
-    void requestPetExpression(const QString &state, const QString &expression);
+    void requestPetExpression(
+        const QString &state,
+        const QString &expression,
+        InterruptHint interruptHint = InterruptHint::Immediate
+    );
     QString sidecarExecutablePath() const;
     void handleStreamBytes(const QByteArray &bytes);
     void finishCurrentReply();

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -208,9 +208,32 @@ void PetRuntime::playActionFromPool(const QString &poolId)
 
 void PetRuntime::submitActionRequest(const ActionRequest &request)
 {
+    if (request.kind == ActionRequestKind::None) {
+        if (request.hideCurrentProp) {
+            executeActionRequest(request);
+        }
+        return;
+    }
+
+    if (request.interruptHint == InterruptHint::AfterCurrent && shouldDeferActionRequest(request)) {
+        m_pendingRequest = request;
+        return;
+    }
+
+    if (request.interruptHint == InterruptHint::Immediate) {
+        m_pendingRequest = ActionRequest::none();
+    }
+
+    executeActionRequest(request);
+}
+
+void PetRuntime::executeActionRequest(const ActionRequest &request)
+{
     if (request.hideCurrentProp) {
         hideCurrentProp();
     }
+
+    applyRequestState(request);
 
     switch (request.kind) {
     case ActionRequestKind::None:
@@ -301,24 +324,38 @@ void PetRuntime::startStartupSequence()
 
 void PetRuntime::requestExpression(const QString &state, const QString &expression)
 {
-    submitExpressionRequest(state, expression, QRandomGenerator::global()->generateDouble());
+    requestExpression(state, expression, InterruptHint::Immediate);
+}
+
+void PetRuntime::requestExpression(const QString &state, const QString &expression, InterruptHint interruptHint)
+{
+    submitExpressionRequest(state, expression, QRandomGenerator::global()->generateDouble(), interruptHint);
 }
 
 void PetRuntime::submitExpressionRequest(const QString &state, const QString &expression, double randomValue)
 {
+    submitExpressionRequest(state, expression, randomValue, InterruptHint::Immediate);
+}
+
+void PetRuntime::submitExpressionRequest(
+    const QString &state,
+    const QString &expression,
+    double randomValue,
+    InterruptHint interruptHint
+)
+{
     const QString requestedState = state.trimmed();
     QString eventState = m_currentState;
-    if (!requestedState.isEmpty() && m_manifest.stateToAction.contains(requestedState) && requestedState != m_currentState) {
-        // expression 请求来自未来的聊天 / agent 层。这里先更新 PetState，
-        // 再把“表达选择”交给 InteractionPipeline 转成 ActionRequest。
-        m_currentState = requestedState;
-        eventState = requestedState;
-        emit currentStateChanged();
-    } else if (!requestedState.isEmpty() && m_manifest.stateToAction.contains(requestedState)) {
+    if (!requestedState.isEmpty() && m_manifest.stateToAction.contains(requestedState)) {
         eventState = requestedState;
     }
 
-    submitRuntimeEvent(PetEvent::agentExpressionRequested(eventState, expression, randomValue));
+    if (interruptHint == InterruptHint::Immediate && eventState != m_currentState) {
+        m_currentState = eventState;
+        emit currentStateChanged();
+    }
+
+    submitRuntimeEvent(PetEvent::agentExpressionRequested(eventState, expression, randomValue, interruptHint));
 }
 
 QVariantMap PetRuntime::consumeFrameMovementDelta() const
@@ -404,6 +441,11 @@ void PetRuntime::handleAnimationFinished()
         }
 
         clearActiveRecipe();
+    }
+
+    if (m_pendingRequest.kind != ActionRequestKind::None) {
+        submitPendingActionRequest();
+        return;
     }
 
     if (m_currentAutoReturnToIdle) {
@@ -598,6 +640,44 @@ bool PetRuntime::submitRuntimeEvent(const PetEvent &event)
         submitActionRequest(request);
     }
     return !requests.isEmpty();
+}
+
+bool PetRuntime::shouldDeferActionRequest(const ActionRequest &request) const
+{
+    if (request.kind == ActionRequestKind::None) {
+        return false;
+    }
+
+    if (m_currentActionId.isEmpty()) {
+        return false;
+    }
+
+    return m_currentAutoReturnToIdle
+        || !m_currentRecipeId.isEmpty()
+        || m_currentLoopMode == QStringLiteral("once");
+}
+
+void PetRuntime::submitPendingActionRequest()
+{
+    ActionRequest request = m_pendingRequest;
+    m_pendingRequest = ActionRequest::none();
+    request.interruptHint = InterruptHint::Immediate;
+    executeActionRequest(request);
+}
+
+void PetRuntime::applyRequestState(const ActionRequest &request)
+{
+    const QString requestedState = request.petState.trimmed();
+    if (requestedState.isEmpty() || !m_manifest.stateToAction.contains(requestedState)) {
+        return;
+    }
+
+    if (m_currentState == requestedState) {
+        return;
+    }
+
+    m_currentState = requestedState;
+    emit currentStateChanged();
 }
 
 void PetRuntime::applyFacingAfterCurrentAction(const ActionDefinition &action)

--- a/apps/desktop/src/pet/PetRuntime.h
+++ b/apps/desktop/src/pet/PetRuntime.h
@@ -148,12 +148,19 @@ public:
     Q_INVOKABLE void returnToIdle();
     // 由 agent / 模型提交一个表达请求；走 ExpressionMappingResolver 转成 ActionRequest。
     Q_INVOKABLE void requestExpression(const QString &state, const QString &expression);
+    void requestExpression(const QString &state, const QString &expression, InterruptHint interruptHint);
     // 表层（QMovie）报告当前动画播完，触发后续 recipe step / action.completed 行为触发。
     Q_INVOKABLE void handleAnimationFinished();
 
     // ---- 主要外部入口：交互管线产出的 ActionRequest 全部从这里进入 ----
     void submitActionRequest(const ActionRequest &request);
     void submitExpressionRequest(const QString &state, const QString &expression, double randomValue);
+    void submitExpressionRequest(
+        const QString &state,
+        const QString &expression,
+        double randomValue,
+        InterruptHint interruptHint
+    );
 
 signals:
     void currentStateChanged();
@@ -197,6 +204,10 @@ private:
     QString resolveRecipeFacing(const QString &facing) const;
     double movementScaleFactor() const;
     bool submitRuntimeEvent(const PetEvent &event);
+    bool shouldDeferActionRequest(const ActionRequest &request) const;
+    void executeActionRequest(const ActionRequest &request);
+    void submitPendingActionRequest();
+    void applyRequestState(const ActionRequest &request);
     void applyFacingAfterCurrentAction(const ActionDefinition &action);
     void updateFacingFromMovementDirection(const QString &movementDirection);
     void playPhase(const QString &actionId, const QString &phaseId);
@@ -227,6 +238,7 @@ private:
     QUrl m_currentAnimationUrl;
     PropController m_propController;
     int m_playbackSerial = 0;
+    ActionRequest m_pendingRequest;
 };
 
 // 与 DesktopShellControllerForeign 一样，这个 wrapper 让 QML 看到一个名为

--- a/apps/desktop/src/pet/events/PetEvent.h
+++ b/apps/desktop/src/pet/events/PetEvent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pet/requests/ActionRequest.h"
+
 #include <QString>
 
 // PetEvent 描述“发生了什么”，不描述要播放什么。
@@ -34,6 +36,7 @@ struct PetEvent
     QString propId;
     QString state;
     QString expression;
+    InterruptHint interruptHint = InterruptHint::Immediate;
     double x = 0.0;
     double y = 0.0;
     double width = 0.0;
@@ -132,12 +135,18 @@ struct PetEvent
         return event;
     }
 
-    static PetEvent agentExpressionRequested(const QString &stateId, const QString &expressionId, double random)
+    static PetEvent agentExpressionRequested(
+        const QString &stateId,
+        const QString &expressionId,
+        double random,
+        InterruptHint hint = InterruptHint::Immediate
+    )
     {
         PetEvent event;
         event.type = PetEventType::AgentExpressionRequested;
         event.state = stateId.trimmed();
         event.expression = expressionId.trimmed();
+        event.interruptHint = hint;
         event.randomValue = random;
         event.hasRandomValue = true;
         return event;

--- a/apps/desktop/src/pet/interaction/InteractionPipeline.cpp
+++ b/apps/desktop/src/pet/interaction/InteractionPipeline.cpp
@@ -276,7 +276,12 @@ QList<ActionRequest> InteractionPipeline::handleEvent(
             event.state.isEmpty() ? snapshot.currentState : event.state,
             event.randomValue,
         };
-        appendIfPlayable(requests, ExpressionMappingResolver::resolve(manifest, context, event.expression));
+        appendIfPlayable(
+            requests,
+            ExpressionMappingResolver::resolve(manifest, context, event.expression)
+                .withInterruptHint(event.interruptHint)
+                .withPetState(context.state)
+        );
         return requests;
     }
     }

--- a/apps/desktop/src/pet/requests/ActionRequest.h
+++ b/apps/desktop/src/pet/requests/ActionRequest.h
@@ -37,6 +37,7 @@ struct ActionRequest
 {
     ActionRequestKind kind = ActionRequestKind::None;
     InterruptHint interruptHint = InterruptHint::Immediate;
+    QString petState;
     QString targetId;
     QVariantMap options;
     bool hideCurrentProp = false;
@@ -107,6 +108,20 @@ struct ActionRequest
     {
         ActionRequest copy = *this;
         copy.hideCurrentProp = true;
+        return copy;
+    }
+
+    ActionRequest withInterruptHint(InterruptHint hint) const
+    {
+        ActionRequest copy = *this;
+        copy.interruptHint = hint;
+        return copy;
+    }
+
+    ActionRequest withPetState(const QString &state) const
+    {
+        ActionRequest copy = *this;
+        copy.petState = state.trimmed();
         return copy;
     }
 };

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -61,6 +61,16 @@ int main()
     const QString speakingAction = runtime.currentActionId();
     require(runtime.currentAutoReturnToIdle(), "speaking objection action should return to idle after animation completion");
 
+    ChatStreamEvent idleAfterCurrentEvent;
+    idleAfterCurrentEvent.type = QStringLiteral("CUSTOM");
+    idleAfterCurrentEvent.name = QStringLiteral("miles.pet.expression.requested");
+    idleAfterCurrentEvent.value.insert(QStringLiteral("state"), QStringLiteral("idle"));
+    idleAfterCurrentEvent.value.insert(QStringLiteral("expression"), QStringLiteral("neutral"));
+    idleAfterCurrentEvent.value.insert(QStringLiteral("interruptHint"), QStringLiteral("afterCurrent"));
+    controller.applyStreamEvent(idleAfterCurrentEvent);
+    require(runtime.currentState() == QStringLiteral("speaking"), "afterCurrent idle expression should not change state immediately");
+    require(runtime.currentActionId() == speakingAction, "afterCurrent idle expression should not interrupt the current speaking action");
+
     ChatStreamEvent finished;
     finished.type = QStringLiteral("RUN_FINISHED");
     finished.runId = QStringLiteral("mock-run");
@@ -68,6 +78,10 @@ int main()
     require(!controller.sending(), "RUN_FINISHED should clear sending");
     require(runtime.currentState() == QStringLiteral("speaking"), "RUN_FINISHED should not interrupt the current speaking state");
     require(runtime.currentActionId() == speakingAction, "RUN_FINISHED should not restart or replace the current speaking action");
+
+    runtime.handleAnimationFinished();
+    require(runtime.currentState() == QStringLiteral("idle"), "pending afterCurrent idle expression should run after speaking animation finishes");
+    require(runtime.currentActionId() == QStringLiteral("idle_stand"), "pending afterCurrent idle expression should return to idle action");
 
     ChatStreamEvent errorEvent;
     errorEvent.type = QStringLiteral("RUN_ERROR");

--- a/docs/v2/设计方案/桌宠运行时与动画调度设计.md
+++ b/docs/v2/设计方案/桌宠运行时与动画调度设计.md
@@ -243,7 +243,7 @@ flowchart LR
 它属于运行时请求，不写进皮肤 manifest。皮肤 manifest 只描述素材、动作和 recipe
 能怎么播放，不决定所有场景下是否打断当前动画。
 
-当前 `ActionRequestKind` 已包含 `ActionPool`、`Recipe`、`Action`、`ReturnToIdle`、`ToggleFacing`、`SpawnProp` 和 `PlaySound`。`interruptHint` 字段已经在结构里保留，但现阶段播放入口主要仍按即时执行模型工作；更复杂的 `afterCurrent` 排队策略应在 `PlaybackController` / `RecipeRunner` 拆分时统一实现。
+当前 `ActionRequestKind` 已包含 `ActionPool`、`Recipe`、`Action`、`ReturnToIdle`、`ToggleFacing`、`SpawnProp` 和 `PlaySound`。`interruptHint=afterCurrent` 已支持一个 `pendingRequest` 槽：当当前动作有自然完成边界时，新请求会等当前动作播完后执行；更复杂的多队列、优先级抢占和 phase exit 编排仍应在 `PlaybackController` / `RecipeRunner` 拆分时统一实现。
 
 ### Action
 
@@ -559,7 +559,7 @@ sequence         由多个 Action 或 Clip 顺序组成的高级动作
 
 MVP 不做全局动画队列。
 
-当前实现比目标模型更简单：`PetRuntime::submitActionRequest()` 收到请求后直接执行对应 action / recipe / pool / sound / prop；`ActionRequest::interruptHint` 已存在但尚未真正驱动 `afterCurrent` 排队。下面的 `pendingRequest` 是下一步抽 `PlaybackController` / `RecipeRunner` 时的目标模型，避免在当前 `PetRuntime` 中继续堆调度分支。
+当前实现仍不做全局队列，但 `PetRuntime::submitActionRequest()` 已支持 `ActionRequest::interruptHint` 的第一版语义。`immediate` 请求直接执行并清空 pending；`afterCurrent` 请求在当前动作具备自然完成边界时写入单槽 `pendingRequest`，等当前动作播完后执行。复杂多队列策略仍后置，避免在当前 `PetRuntime` 中继续堆调度分支。
 
 运行时只维护：
 
@@ -905,8 +905,8 @@ Phase 0 / 1 已实现必要桌宠运行时能力：
 - `oneshot`
 - 左右朝向变体。
 - 8 方向移动动画。
-- `currentAction + currentRecipe` 的即时调度。
-- `ActionRequest::interruptHint` 字段保留；复杂 `afterCurrent` 排队尚未完整驱动。
+- `currentAction + currentRecipe + pendingRequest` 的最小调度。
+- `ActionRequest::interruptHint = immediate / afterCurrent`，其中 `afterCurrent` 支持单槽 pending，在当前动作自然完成后执行。
 - 空闲随机动作。
 - 鼠标交互。
 - 检察官徽章和音效。

--- a/docs/v2/设计方案/皮肤包播放行为设计.md
+++ b/docs/v2/设计方案/皮肤包播放行为设计.md
@@ -767,7 +767,7 @@ BehaviorRule 字段建议：
 | `pool` | string | 从 action pool 中选择。 |
 | `expression` | string | 目标模型，请求 expression mapping。 |
 | `priority` | number | 目标模型，请求优先级。 |
-| `interruptHint` | string | 请求切换提示，当前结构保留，复杂排队后续实现。 |
+| `interruptHint` | string | 请求切换提示；`immediate` 立即切换，`afterCurrent` 等当前动作自然完成后切换。 |
 | `sideEffects` | array | 目标模型，气泡、音效等副作用。 |
 
 ```json


### PR DESCRIPTION
## 变更摘要

- 恢复 mock sidecar 在正常回复结束时发送 `state=idle / expression=neutral` 语义事件，并为该事件增加 `interruptHint=afterCurrent`。
- 将聊天流里的 `interruptHint` 传入 `PetEvent -> InteractionPipeline -> ActionRequest -> PetRuntime` 主链路。
- 在 `PetRuntime` 落地单槽 `pendingRequest`：`afterCurrent` 请求会等当前可自然结束的动画播完再执行，`immediate` 请求仍立即切换。
- 补充回归测试，覆盖 `speaking/objecting` 收到 idle afterCurrent 后不立即切 idle，动画完成后再回 idle。
- 更新设计文档，把 `afterCurrent` 从“字段保留”改成当前已支持的最小 pending 调度。

## 根因

上一版只移除了 mock provider 的 idle 事件，解决了眼前症状，但没有覆盖未来模型主动发送情绪/状态变化事件的情况。正确边界应该是：事件可以继续发，转成 `ActionRequest` 后由 `interruptHint` 决定是否立即打断当前动画。

## 验证

- 先新增并运行失败测试：`chat_controller_smoke` 在修复前会因为 afterCurrent idle 立即改 state/action 而失败。
- 先更新并运行失败测试：`go test ./internal/api -run TestMockChatStream -count=1` 在恢复 provider 前会因为缺少 idle/afterCurrent 事件而失败。
- `(cd apps/agent-core && go test ./...)`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`：73/73 通过
- 使用构建后的 `miles-agent` 请求 `/v1/chat/messages`，确认 SSE 中正常结束会发送 `state=idle` 且带 `interruptHint=afterCurrent`。