### PR TITLE
Phase 2.1：接入 OpenAI-compatible Provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,5 +569,13 @@ if(BUILD_TESTING)
                     ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_0_ai_chat_mvp.py
         )
 
+        # Phase 2.1 的 OpenAI-compatible provider 检查：守住
+        # provider 配置、[EXPR:x] 解析、Qt 请求表达清单和阶段记录。
+        add_test(
+            NAME check_phase_2_1_provider
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_1_provider.py
+        )
+
     endif()
 endif()

--- a/apps/agent-core/cmd/miles-agent/main.go
+++ b/apps/agent-core/cmd/miles-agent/main.go
@@ -12,15 +12,29 @@ import (
 
 	"milesedgeworth/agent-core/internal/api"
 	"milesedgeworth/agent-core/internal/chat"
+	"milesedgeworth/agent-core/internal/chat/config"
+	"milesedgeworth/agent-core/internal/chat/openai"
 )
 
 func main() {
-	addr := flag.String("addr", "127.0.0.1:39710", "listen address")
+	addr := flag.String("addr", api.DefaultListenAddr, "listen address")
 	flag.Parse()
+
+	cfg := config.FromEnv()
+	var provider chat.Provider
+	label := "mock-fallback"
+	if cfg.Enabled() {
+		provider = openai.NewProvider(cfg.BaseURL, cfg.APIKey, cfg.Model, cfg.Temperature, cfg.MaxTokens)
+		label = "openai-compatible"
+		log.Printf("provider: openai-compatible model=%s", cfg.Model)
+	} else {
+		provider = chat.NewMockProvider(35 * time.Millisecond)
+		log.Printf("provider: mock-fallback (set MILES_PROVIDER_BASE_URL, MILES_PROVIDER_API_KEY, MILES_PROVIDER_MODEL to use a real provider)")
+	}
 
 	server := &http.Server{
 		Addr:    *addr,
-		Handler: api.NewServer(chat.NewMockProvider(35 * time.Millisecond)).Routes(),
+		Handler: api.NewServer(provider, label).Routes(),
 	}
 
 	errs := make(chan error, 1)

--- a/apps/agent-core/internal/api/server.go
+++ b/apps/agent-core/internal/api/server.go
@@ -8,12 +8,26 @@ import (
 	"milesedgeworth/agent-core/internal/chat"
 )
 
+const (
+	// DefaultListenAddr is the localhost:port the desktop app expects the sidecar on.
+	// Kept in sync with apps/desktop/src/chat/ChatController.cpp.
+	DefaultListenAddr = "127.0.0.1:39710"
+
+	// MaxRequestBodyBytes caps incoming chat request bodies to avoid runaway upstreams
+	// or accidental large payloads pinning sidecar memory.
+	MaxRequestBodyBytes = 1 * 1024 * 1024
+)
+
 type Server struct {
-	provider chat.Provider
+	provider      chat.Provider
+	providerLabel string
 }
 
-func NewServer(provider chat.Provider) *Server {
-	return &Server{provider: provider}
+func NewServer(provider chat.Provider, providerLabel string) *Server {
+	if providerLabel == "" {
+		providerLabel = "unknown"
+	}
+	return &Server{provider: provider, providerLabel: providerLabel}
 }
 
 func (s *Server) Routes() http.Handler {
@@ -31,7 +45,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":       true,
-		"provider": "mock",
+		"provider": s.providerLabel,
 		"service":  "miles-agent",
 	})
 }
@@ -42,6 +56,7 @@ func (s *Server) handleChatMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBodyBytes)
 	var req chat.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON"})

--- a/apps/agent-core/internal/api/server_test.go
+++ b/apps/agent-core/internal/api/server_test.go
@@ -96,3 +96,7 @@ func TestChatStreamRejectsEmptyMessage(t *testing.T) {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
 }
+
+func TestChatStreamForwardsExpressions(t *testing.T) {
+	t.Skip("enabled in Task 9 once api.NewServer accepts a provider label")
+}

--- a/apps/agent-core/internal/api/server_test.go
+++ b/apps/agent-core/internal/api/server_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0)).Routes())
+	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0), "mock").Routes())
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + "/health")
@@ -41,7 +42,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestMockChatStream(t *testing.T) {
-	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0)).Routes())
+	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0), "mock").Routes())
 	defer server.Close()
 
 	payload := []byte(`{"conversationId":"default","message":"hello miles"}`)
@@ -83,7 +84,7 @@ func TestMockChatStream(t *testing.T) {
 }
 
 func TestChatStreamRejectsEmptyMessage(t *testing.T) {
-	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(time.Millisecond)).Routes())
+	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(time.Millisecond), "mock").Routes())
 	defer server.Close()
 
 	resp, err := http.Post(server.URL+"/v1/chat/messages", "application/json", strings.NewReader(`{"message":"   "}`))
@@ -98,5 +99,40 @@ func TestChatStreamRejectsEmptyMessage(t *testing.T) {
 }
 
 func TestChatStreamForwardsExpressions(t *testing.T) {
-	t.Skip("enabled in Task 9 once api.NewServer accepts a provider label")
+	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0), "mock").Routes())
+	defer server.Close()
+
+	payload := []byte(`{
+		"conversationId": "default",
+		"message": "hi",
+		"expressions": [
+			{"id": "objection", "description": "strong rebuttal"},
+			{"id": "polite"}
+		]
+	}`)
+	resp, err := http.Post(server.URL+"/v1/chat/messages", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// Mock doesn't currently echo expressions; we just verify decoding doesn't blow up.
+}
+
+func TestChatStreamRejectsOversizedBody(t *testing.T) {
+	server := httptest.NewServer(api.NewServer(chat.NewMockProvider(0), "mock").Routes())
+	defer server.Close()
+
+	huge := strings.Repeat("x", 2*1024*1024)
+	body := fmt.Sprintf(`{"message":"%s"}`, huge)
+	resp, err := http.Post(server.URL+"/v1/chat/messages", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge && resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 413 or 400", resp.StatusCode)
+	}
 }

--- a/apps/agent-core/internal/chat/config/config.go
+++ b/apps/agent-core/internal/chat/config/config.go
@@ -1,0 +1,57 @@
+// Package config exposes provider configuration sourced from environment variables.
+package config
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+type ProviderConfig struct {
+	BaseURL     string
+	APIKey      string
+	Model       string
+	Temperature float64
+	MaxTokens   int
+}
+
+const (
+	defaultTemperature = 0.7
+	defaultMaxTokens   = 2048
+)
+
+func FromEnv() ProviderConfig {
+	return ProviderConfig{
+		BaseURL:     strings.TrimSpace(os.Getenv("MILES_PROVIDER_BASE_URL")),
+		APIKey:      strings.TrimSpace(os.Getenv("MILES_PROVIDER_API_KEY")),
+		Model:       strings.TrimSpace(os.Getenv("MILES_PROVIDER_MODEL")),
+		Temperature: parseFloat(os.Getenv("MILES_PROVIDER_TEMPERATURE"), defaultTemperature),
+		MaxTokens:   parseInt(os.Getenv("MILES_PROVIDER_MAX_TOKENS"), defaultMaxTokens),
+	}
+}
+
+func (c ProviderConfig) Enabled() bool {
+	return c.BaseURL != "" && c.APIKey != "" && c.Model != ""
+}
+
+func parseFloat(s string, def float64) float64 {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+func parseInt(s string, def int) int {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return def
+	}
+	return v
+}

--- a/apps/agent-core/internal/chat/config/config_test.go
+++ b/apps/agent-core/internal/chat/config/config_test.go
@@ -1,0 +1,80 @@
+package config_test
+
+import (
+	"testing"
+
+	"milesedgeworth/agent-core/internal/chat/config"
+)
+
+func TestFromEnv(t *testing.T) {
+	t.Setenv("MILES_PROVIDER_BASE_URL", "https://api.example.com")
+	t.Setenv("MILES_PROVIDER_API_KEY", "sk-test")
+	t.Setenv("MILES_PROVIDER_MODEL", "gpt-test")
+	t.Setenv("MILES_PROVIDER_TEMPERATURE", "0.3")
+	t.Setenv("MILES_PROVIDER_MAX_TOKENS", "1024")
+
+	cfg := config.FromEnv()
+
+	if cfg.BaseURL != "https://api.example.com" {
+		t.Fatalf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.APIKey != "sk-test" {
+		t.Fatalf("APIKey = %q", cfg.APIKey)
+	}
+	if cfg.Model != "gpt-test" {
+		t.Fatalf("Model = %q", cfg.Model)
+	}
+	if cfg.Temperature != 0.3 {
+		t.Fatalf("Temperature = %v", cfg.Temperature)
+	}
+	if cfg.MaxTokens != 1024 {
+		t.Fatalf("MaxTokens = %v", cfg.MaxTokens)
+	}
+	if !cfg.Enabled() {
+		t.Fatal("Enabled should be true when all required env set")
+	}
+}
+
+func TestFromEnvDefaults(t *testing.T) {
+	t.Setenv("MILES_PROVIDER_BASE_URL", "")
+	t.Setenv("MILES_PROVIDER_API_KEY", "")
+	t.Setenv("MILES_PROVIDER_MODEL", "")
+	t.Setenv("MILES_PROVIDER_TEMPERATURE", "")
+	t.Setenv("MILES_PROVIDER_MAX_TOKENS", "")
+
+	cfg := config.FromEnv()
+
+	if cfg.Temperature != 0.7 {
+		t.Fatalf("default Temperature should be 0.7, got %v", cfg.Temperature)
+	}
+	if cfg.MaxTokens != 2048 {
+		t.Fatalf("default MaxTokens should be 2048, got %v", cfg.MaxTokens)
+	}
+	if cfg.Enabled() {
+		t.Fatal("Enabled should be false when required env missing")
+	}
+}
+
+func TestEnabledRequiresAllThree(t *testing.T) {
+	cases := []struct {
+		name              string
+		baseURL, key, mdl string
+		want              bool
+	}{
+		{"all set", "https://x", "k", "m", true},
+		{"missing baseURL", "", "k", "m", false},
+		{"missing key", "https://x", "", "m", false},
+		{"missing model", "https://x", "k", "", false},
+		{"whitespace only", "  ", "k", "m", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MILES_PROVIDER_BASE_URL", tc.baseURL)
+			t.Setenv("MILES_PROVIDER_API_KEY", tc.key)
+			t.Setenv("MILES_PROVIDER_MODEL", tc.mdl)
+			if got := config.FromEnv().Enabled(); got != tc.want {
+				t.Fatalf("Enabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/agent-core/internal/chat/expression/parser.go
+++ b/apps/agent-core/internal/chat/expression/parser.go
@@ -1,0 +1,118 @@
+// Package expression splits a streaming token sequence into TEXT and EXPR events.
+// Markers have the form [EXPR:tag_name]. Unknown tags are downgraded to FallbackTag.
+package expression
+
+import "strings"
+
+const (
+	markerOpen  = "[EXPR:"
+	markerClose = "]"
+)
+
+// Parser is single-pass and not safe for concurrent use.
+// The caller fills KnownTags, FallbackTag, OnText, OnExpression before Feed.
+type Parser struct {
+	KnownTags    []string
+	FallbackTag  string
+	OnText       func(string)
+	OnExpression func(string)
+
+	known  map[string]bool
+	buffer string
+}
+
+// NewParser creates a streaming marker parser with the standard callback shape.
+func NewParser(knownTags []string, fallbackTag string, onText func(string), onExpression func(string)) *Parser {
+	return &Parser{
+		KnownTags:    knownTags,
+		FallbackTag:  fallbackTag,
+		OnText:       onText,
+		OnExpression: onExpression,
+	}
+}
+
+func (p *Parser) ensureKnown() {
+	if p.known != nil {
+		return
+	}
+	p.known = make(map[string]bool, len(p.KnownTags))
+	for _, t := range p.KnownTags {
+		p.known[t] = true
+	}
+}
+
+// Feed appends chunk and emits any complete text/marker events.
+// Unparseable suffix is held in buffer until the next Feed or Flush.
+func (p *Parser) Feed(chunk string) {
+	p.ensureKnown()
+	p.buffer += chunk
+	for p.consume() {
+	}
+}
+
+// Flush emits any held buffer as text. Call once after the stream ends.
+func (p *Parser) Flush() {
+	if p.buffer == "" {
+		return
+	}
+	if p.OnText != nil {
+		p.OnText(p.buffer)
+	}
+	p.buffer = ""
+}
+
+// consume tries to emit one event. Returns true if it made progress.
+func (p *Parser) consume() bool {
+	idx := strings.Index(p.buffer, markerOpen)
+	if idx == -1 {
+		// No marker possible; emit safe prefix, hold ambiguous tail.
+		safe, tail := splitSafeForPrefix(p.buffer, markerOpen)
+		if safe != "" && p.OnText != nil {
+			p.OnText(safe)
+		}
+		p.buffer = tail
+		return false
+	}
+
+	if idx > 0 {
+		if p.OnText != nil {
+			p.OnText(p.buffer[:idx])
+		}
+		p.buffer = p.buffer[idx:]
+	}
+
+	// buffer now starts with markerOpen.
+	endIdx := strings.Index(p.buffer, markerClose)
+	if endIdx == -1 {
+		// Marker incomplete; wait for more chunks.
+		return false
+	}
+
+	tag := p.buffer[len(markerOpen):endIdx]
+	p.buffer = p.buffer[endIdx+len(markerClose):]
+
+	if p.OnExpression != nil {
+		if p.known[tag] {
+			p.OnExpression(tag)
+		} else {
+			p.OnExpression(p.FallbackTag)
+		}
+	}
+	return true
+}
+
+// splitSafeForPrefix returns (safe, tail) where tail is any suffix of s that
+// could still grow into prefix. Used to decide what to flush vs hold when no
+// complete marker is found yet.
+func splitSafeForPrefix(s, prefix string) (string, string) {
+	maxK := len(prefix) - 1
+	if maxK > len(s) {
+		maxK = len(s)
+	}
+	for k := maxK; k > 0; k-- {
+		if strings.HasPrefix(prefix, s[len(s)-k:]) {
+			return s[:len(s)-k], s[len(s)-k:]
+		}
+	}
+	return s, ""
+}

--- a/apps/agent-core/internal/chat/expression/parser_test.go
+++ b/apps/agent-core/internal/chat/expression/parser_test.go
@@ -63,3 +63,68 @@ func TestParserMultipleMarkers(t *testing.T) {
 		t.Fatalf("got %q", got)
 	}
 }
+
+func TestParserCrossChunk(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "polite", "neutral"})
+	p.Feed("abc[EX")
+	p.Feed("PR:polite]def")
+	p.Flush()
+	if got := cap.string(); got != "T(abc)E(polite)T(def)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserCrossChunkVeryFragmented(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection"})
+	// One rune at a time (worst case for streaming providers).
+	for _, r := range "[EXPR:objection]hi" {
+		p.Feed(string(r))
+	}
+	p.Flush()
+	if got := cap.string(); got != "E(objection)T(h)T(i)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserUnknownTag(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "neutral"})
+	p.Feed("[EXPR:mystery]hi")
+	p.Flush()
+	if got := cap.string(); got != "E(neutral)T(hi)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserHalfMarkerAtEnd(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection"})
+	p.Feed("text[EX")
+	p.Flush()
+	// On flush the held "[EX" surfaces as text rather than being lost.
+	if got := cap.string(); got != "T(text)T([EX)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserNonMarkerBracket(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection"})
+	p.Feed("array[0]=1")
+	p.Flush()
+	if got := cap.string(); got != "T(array[0]=1)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserEmptyTagFallsBack(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "neutral"})
+	p.Feed("[EXPR:]hi")
+	p.Flush()
+	if got := cap.string(); got != "E(neutral)T(hi)" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/apps/agent-core/internal/chat/expression/parser_test.go
+++ b/apps/agent-core/internal/chat/expression/parser_test.go
@@ -1,0 +1,65 @@
+package expression_test
+
+import (
+	"strings"
+	"testing"
+
+	"milesedgeworth/agent-core/internal/chat/expression"
+)
+
+type capture struct {
+	out strings.Builder
+}
+
+func (c *capture) text(s string)   { c.out.WriteString("T(" + s + ")") }
+func (c *capture) expr(tag string) { c.out.WriteString("E(" + tag + ")") }
+func (c *capture) string() string  { return c.out.String() }
+
+func newParser(c *capture, known []string) *expression.Parser {
+	return &expression.Parser{
+		KnownTags:    known,
+		FallbackTag:  "neutral",
+		OnText:       c.text,
+		OnExpression: c.expr,
+	}
+}
+
+func TestParserPlainText(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "polite", "neutral"})
+	p.Feed("hello world")
+	p.Flush()
+	if got := cap.string(); got != "T(hello world)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserMarkerAtStart(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "polite", "neutral"})
+	p.Feed("[EXPR:objection]异议！")
+	p.Flush()
+	if got := cap.string(); got != "E(objection)T(异议！)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserMarkerInMiddle(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "polite", "neutral"})
+	p.Feed("hello [EXPR:polite]world")
+	p.Flush()
+	if got := cap.string(); got != "T(hello )E(polite)T(world)" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParserMultipleMarkers(t *testing.T) {
+	cap := &capture{}
+	p := newParser(cap, []string{"objection", "polite", "neutral"})
+	p.Feed("[EXPR:objection]一段[EXPR:polite]二段")
+	p.Flush()
+	if got := cap.string(); got != "E(objection)T(一段)E(polite)T(二段)" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -1,0 +1,35 @@
+// Package openai implements an OpenAI-compatible Chat Completions provider.
+package openai
+
+import (
+	"strings"
+
+	"milesedgeworth/agent-core/internal/chat"
+)
+
+// BuildSystemPrompt assembles the persona + expression instruction shown to the model.
+// Phase 2.3 will replace this with the full Miles persona; Phase 2.1 only ships the
+// minimal instruction needed for the [EXPR:tag] protocol to function.
+func BuildSystemPrompt(expressions []chat.ExpressionInfo) string {
+	return buildSystemPrompt(expressions)
+}
+
+func buildSystemPrompt(expressions []chat.ExpressionInfo) string {
+	var sb strings.Builder
+	sb.WriteString("你是 Miles Edgeworth 桌宠助手。回复时在每段文字开头用 [EXPR:标签名] 标记当前表达。")
+	sb.WriteString("情绪延续时不重复标记。回复的第一段文字必须有标记。\n\n")
+	if len(expressions) == 0 {
+		return sb.String()
+	}
+	sb.WriteString("当前可用表达标签：\n")
+	for _, e := range expressions {
+		sb.WriteString("- ")
+		sb.WriteString(e.ID)
+		if e.Description != "" {
+			sb.WriteString("：")
+			sb.WriteString(e.Description)
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -155,7 +155,7 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 			defer close(events)
 			send(ctx, events, chat.StreamEvent{
 				Type:  "RUN_ERROR",
-				Error: fmt.Sprintf("provider returned %d: %s", resp.StatusCode, strings.TrimSpace(string(sample))),
+				Error: providerErrorMessage(resp, p.baseURL, sample),
 			})
 		}()
 		return events, nil
@@ -168,6 +168,35 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 
 	go p.pipe(ctx, resp, events, knownTags)
 	return events, nil
+}
+
+func providerErrorMessage(resp *http.Response, endpoint string, sample []byte) string {
+	message := fmt.Sprintf("provider returned %d from %s", resp.StatusCode, sanitizeEndpoint(endpoint))
+	var diagnostics []string
+	if errorCode := strings.TrimSpace(resp.Header.Get("X-Error-Code")); errorCode != "" {
+		diagnostics = append(diagnostics, "x-error-code="+errorCode)
+	}
+	if requestID := strings.TrimSpace(resp.Header.Get("X-Request-Id")); requestID != "" {
+		diagnostics = append(diagnostics, "x-request-id="+requestID)
+	}
+	if len(diagnostics) > 0 {
+		message += " (" + strings.Join(diagnostics, ", ") + ")"
+	}
+	if body := strings.TrimSpace(string(sample)); body != "" {
+		message += ": " + body
+	}
+	return message
+}
+
+func sanitizeEndpoint(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
 }
 
 func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- chat.StreamEvent, knownTags []string) {

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -2,10 +2,39 @@
 package openai
 
 import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"milesedgeworth/agent-core/internal/chat"
+	"milesedgeworth/agent-core/internal/chat/expression"
 )
+
+type Provider struct {
+	baseURL     string
+	apiKey      string
+	model       string
+	temperature float64
+	maxTokens   int
+	httpClient  *http.Client
+}
+
+func NewProvider(baseURL, apiKey, model string, temperature float64, maxTokens int) *Provider {
+	return &Provider{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		apiKey:      apiKey,
+		model:       model,
+		temperature: temperature,
+		maxTokens:   maxTokens,
+		httpClient:  &http.Client{Timeout: 120 * time.Second},
+	}
+}
 
 // BuildSystemPrompt assembles the persona + expression instruction shown to the model.
 // Phase 2.3 will replace this with the full Miles persona; Phase 2.1 only ships the
@@ -32,4 +61,194 @@ func buildSystemPrompt(expressions []chat.ExpressionInfo) string {
 		sb.WriteString("\n")
 	}
 	return sb.String()
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatCompletionRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Stream      bool          `json:"stream"`
+	Temperature float64       `json:"temperature,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+}
+
+type chatCompletionStreamChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+	} `json:"choices"`
+}
+
+const (
+	runID     = "openai-run-1"
+	messageID = "openai-msg-1"
+)
+
+func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan chat.StreamEvent, error) {
+	events := make(chan chat.StreamEvent, 32)
+
+	body := chatCompletionRequest{
+		Model: p.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: BuildSystemPrompt(req.Expressions)},
+			{Role: "user", Content: req.Message},
+		},
+		Stream:      true,
+		Temperature: p.temperature,
+		MaxTokens:   p.maxTokens,
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		close(events)
+		return events, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		p.baseURL+"/v1/chat/completions", bytes.NewReader(encoded))
+	if err != nil {
+		close(events)
+		return events, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		close(events)
+		return events, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain a small sample for diagnostics, then close.
+		sample, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		resp.Body.Close()
+		go func() {
+			defer close(events)
+			send(ctx, events, chat.StreamEvent{
+				Type:  "RUN_ERROR",
+				Error: fmt.Sprintf("provider returned %d: %s", resp.StatusCode, strings.TrimSpace(string(sample))),
+			})
+		}()
+		return events, nil
+	}
+
+	knownTags := make([]string, 0, len(req.Expressions))
+	for _, e := range req.Expressions {
+		knownTags = append(knownTags, e.ID)
+	}
+
+	go p.pipe(ctx, resp, events, knownTags)
+	return events, nil
+}
+
+func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- chat.StreamEvent, knownTags []string) {
+	defer resp.Body.Close()
+	defer close(events)
+
+	if !send(ctx, events, chat.StreamEvent{Type: "RUN_STARTED", RunID: runID}) {
+		return
+	}
+	if !send(ctx, events, chat.StreamEvent{
+		Type:  "CUSTOM",
+		Name:  "miles.pet.expression.requested",
+		RunID: runID,
+		Value: map[string]any{"state": "thinking", "expression": "neutral"},
+	}) {
+		return
+	}
+	if !send(ctx, events, chat.StreamEvent{
+		Type:      "TEXT_MESSAGE_START",
+		RunID:     runID,
+		MessageID: messageID,
+		Role:      "assistant",
+	}) {
+		return
+	}
+
+	sawFirstSpeaking := false
+	parser := expression.NewParser(
+		knownTags,
+		"neutral",
+		func(text string) {
+			if !sawFirstSpeaking {
+				sawFirstSpeaking = true
+				send(ctx, events, chat.StreamEvent{
+					Type:  "CUSTOM",
+					Name:  "miles.pet.expression.requested",
+					RunID: runID,
+					Value: map[string]any{"state": "speaking", "expression": "neutral"},
+				})
+			}
+			send(ctx, events, chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     runID,
+				MessageID: messageID,
+				Delta:     text,
+			})
+		},
+		func(tag string) {
+			sawFirstSpeaking = true
+			send(ctx, events, chat.StreamEvent{
+				Type:  "CUSTOM",
+				Name:  "miles.pet.expression.requested",
+				RunID: runID,
+				Value: map[string]any{"state": "speaking", "expression": tag},
+			})
+		},
+	)
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "[DONE]" {
+			break
+		}
+		var chunk chatCompletionStreamChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, choice := range chunk.Choices {
+			if choice.Delta.Content != "" {
+				parser.Feed(choice.Delta.Content)
+			}
+		}
+	}
+	parser.Flush()
+
+	send(ctx, events, chat.StreamEvent{
+		Type:      "TEXT_MESSAGE_END",
+		RunID:     runID,
+		MessageID: messageID,
+	})
+	send(ctx, events, chat.StreamEvent{
+		Type:  "CUSTOM",
+		Name:  "miles.pet.expression.requested",
+		RunID: runID,
+		Value: map[string]any{
+			"state":         "idle",
+			"expression":    "neutral",
+			"interruptHint": "afterCurrent",
+		},
+	})
+	send(ctx, events, chat.StreamEvent{Type: "RUN_FINISHED", RunID: runID})
+}
+
+func send(ctx context.Context, events chan<- chat.StreamEvent, e chat.StreamEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case events <- e:
+		return true
+	}
 }

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -44,18 +44,18 @@ func normalizeChatCompletionsURL(raw string) string {
 	}
 
 	parsed, err := url.Parse(trimmed)
-	if err != nil || parsed.Path == "" {
+	if err != nil {
 		return trimmed + "/v1/chat/completions"
 	}
 
 	path := strings.TrimRight(parsed.Path, "/")
 	switch {
+	case path == "":
+		return trimmed + "/v1/chat/completions"
 	case strings.HasSuffix(path, "/chat/completions"):
 		return trimmed
-	case strings.HasSuffix(path, "/v1"):
-		return trimmed + "/chat/completions"
 	default:
-		return trimmed + "/v1/chat/completions"
+		return trimmed + "/chat/completions"
 	}
 }
 

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -27,12 +28,34 @@ type Provider struct {
 
 func NewProvider(baseURL, apiKey, model string, temperature float64, maxTokens int) *Provider {
 	return &Provider{
-		baseURL:     strings.TrimRight(baseURL, "/"),
+		baseURL:     normalizeChatCompletionsURL(baseURL),
 		apiKey:      apiKey,
 		model:       model,
 		temperature: temperature,
 		maxTokens:   maxTokens,
 		httpClient:  &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+func normalizeChatCompletionsURL(raw string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return trimmed
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Path == "" {
+		return trimmed + "/v1/chat/completions"
+	}
+
+	path := strings.TrimRight(parsed.Path, "/")
+	switch {
+	case strings.HasSuffix(path, "/chat/completions"):
+		return trimmed
+	case strings.HasSuffix(path, "/v1"):
+		return trimmed + "/chat/completions"
+	default:
+		return trimmed + "/v1/chat/completions"
 	}
 }
 
@@ -109,7 +132,7 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		p.baseURL+"/v1/chat/completions", bytes.NewReader(encoded))
+		p.baseURL, bytes.NewReader(encoded))
 	if err != nil {
 		close(events)
 		return events, err

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -138,3 +138,61 @@ func TestStreamReplyHappyPath(t *testing.T) {
 	}, "idle afterCurrent expression")
 	mustFind(func(e chat.StreamEvent) bool { return e.Type == "RUN_FINISHED" }, "RUN_FINISHED")
 }
+
+func TestStreamReply4xxBecomesRunError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"invalid api key"}}`, http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL, "sk-bad", "any", 0.7, 128)
+	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
+	if err != nil {
+		t.Fatalf("StreamReply returned err: %v", err)
+	}
+	var got []chat.StreamEvent
+	for e := range events {
+		got = append(got, e)
+	}
+	if len(got) != 1 || got[0].Type != "RUN_ERROR" {
+		t.Fatalf("expected single RUN_ERROR, got %+v", got)
+	}
+	if !strings.Contains(got[0].Error, "401") {
+		t.Fatalf("RUN_ERROR should mention status code, got %q", got[0].Error)
+	}
+}
+
+func TestStreamReplySkipsMalformedChunks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		for _, line := range []string{
+			"data: {not-json}",
+			`data: {"choices":[{"delta":{"content":"[EXPR:polite]ok"}}]}`,
+			"data: [DONE]",
+		} {
+			fmt.Fprintf(w, "%s\n\n", line)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL, "sk-test", "any", 0.7, 128)
+	events, err := p.StreamReply(context.Background(), chat.Request{
+		Message:     "hi",
+		Expressions: []chat.ExpressionInfo{{ID: "polite"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	gotPolite := false
+	for e := range events {
+		if e.Type == "CUSTOM" && e.Value["expression"] == "polite" {
+			gotPolite = true
+		}
+	}
+	if !gotPolite {
+		t.Fatal("expected polite expression after malformed chunk was skipped")
+	}
+}

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -164,6 +164,31 @@ func TestStreamReplyAcceptsVersionedBaseURL(t *testing.T) {
 	}
 }
 
+func TestStreamReplyAcceptsProviderVersionPrefix(t *testing.T) {
+	seenPath := ""
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		if seenPath != "/api/v3/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL+"/api/v3", "sk-test", "test-model", 0.5, 256)
+	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	for range events {
+	}
+	if seenPath != "/api/v3/chat/completions" {
+		t.Fatalf("requested path = %q, want /api/v3/chat/completions", seenPath)
+	}
+}
+
 func TestStreamReplyAcceptsFullChatCompletionsURL(t *testing.T) {
 	seenPath := ""
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -139,6 +139,56 @@ func TestStreamReplyHappyPath(t *testing.T) {
 	mustFind(func(e chat.StreamEvent) bool { return e.Type == "RUN_FINISHED" }, "RUN_FINISHED")
 }
 
+func TestStreamReplyAcceptsVersionedBaseURL(t *testing.T) {
+	seenPath := ""
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		if seenPath != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL+"/v1", "sk-test", "test-model", 0.5, 256)
+	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	for range events {
+	}
+	if seenPath != "/v1/chat/completions" {
+		t.Fatalf("requested path = %q, want /v1/chat/completions", seenPath)
+	}
+}
+
+func TestStreamReplyAcceptsFullChatCompletionsURL(t *testing.T) {
+	seenPath := ""
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		if seenPath != "/custom/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL+"/custom/v1/chat/completions", "sk-test", "test-model", 0.5, 256)
+	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	for range events {
+	}
+	if seenPath != "/custom/v1/chat/completions" {
+		t.Fatalf("requested path = %q, want /custom/v1/chat/completions", seenPath)
+	}
+}
+
 func TestStreamReply4xxBecomesRunError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":{"message":"invalid api key"}}`, http.StatusUnauthorized)

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -216,11 +216,17 @@ func TestStreamReplyAcceptsFullChatCompletionsURL(t *testing.T) {
 
 func TestStreamReply4xxBecomesRunError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"error":{"message":"invalid api key"}}`, http.StatusUnauthorized)
+		if r.URL.Path != "/custom/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("X-Error-Code", "InvalidEndpointOrModel.NotFound")
+		w.Header().Set("X-Request-Id", "req-123")
+		http.Error(w, `{"error":{"message":"model not found"}}`, http.StatusNotFound)
 	}))
 	defer upstream.Close()
 
-	p := openai.NewProvider(upstream.URL, "sk-bad", "any", 0.7, 128)
+	p := openai.NewProvider(upstream.URL+"/custom/v1", "sk-bad", "any", 0.7, 128)
 	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
 	if err != nil {
 		t.Fatalf("StreamReply returned err: %v", err)
@@ -232,7 +238,44 @@ func TestStreamReply4xxBecomesRunError(t *testing.T) {
 	if len(got) != 1 || got[0].Type != "RUN_ERROR" {
 		t.Fatalf("expected single RUN_ERROR, got %+v", got)
 	}
-	if !strings.Contains(got[0].Error, "401") {
+	for _, want := range []string{
+		"404",
+		upstream.URL + "/custom/v1/chat/completions",
+		"x-error-code=InvalidEndpointOrModel.NotFound",
+		"x-request-id=req-123",
+		"model not found",
+	} {
+		if !strings.Contains(got[0].Error, want) {
+			t.Fatalf("RUN_ERROR should mention %q, got %q", want, got[0].Error)
+		}
+	}
+	if strings.Contains(got[0].Error, "sk-bad") {
+		t.Fatalf("RUN_ERROR must not leak the API key, got %q", got[0].Error)
+	}
+}
+
+func TestStreamReply4xxSanitizesEndpointDiagnostics(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "denied", http.StatusForbidden)
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(strings.Replace(upstream.URL, "://", "://user:pass@", 1), "sk-test", "any", 0.7, 128)
+	events, err := p.StreamReply(context.Background(), chat.Request{Message: "hi"})
+	if err != nil {
+		t.Fatalf("StreamReply returned err: %v", err)
+	}
+	var got []chat.StreamEvent
+	for e := range events {
+		got = append(got, e)
+	}
+	if len(got) != 1 || got[0].Type != "RUN_ERROR" {
+		t.Fatalf("expected single RUN_ERROR, got %+v", got)
+	}
+	if strings.Contains(got[0].Error, "user:pass") {
+		t.Fatalf("RUN_ERROR must not leak URL userinfo, got %q", got[0].Error)
+	}
+	if !strings.Contains(got[0].Error, upstream.URL+"/v1/chat/completions") {
 		t.Fatalf("RUN_ERROR should mention status code, got %q", got[0].Error)
 	}
 }

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -1,0 +1,39 @@
+package openai_test
+
+import (
+	"strings"
+	"testing"
+
+	"milesedgeworth/agent-core/internal/chat"
+	"milesedgeworth/agent-core/internal/chat/openai"
+)
+
+func TestBuildSystemPromptIncludesAllExpressions(t *testing.T) {
+	exprs := []chat.ExpressionInfo{
+		{ID: "neutral", Description: "默认状态"},
+		{ID: "objection", Description: "强烈反驳"},
+		{ID: "polite"},
+	}
+	prompt := openai.BuildSystemPrompt(exprs)
+
+	for _, expect := range []string{
+		"[EXPR:",
+		"neutral",
+		"默认状态",
+		"objection",
+		"强烈反驳",
+		"polite",
+	} {
+		if !strings.Contains(prompt, expect) {
+			t.Fatalf("prompt missing %q\n---\n%s", expect, prompt)
+		}
+	}
+}
+
+func TestBuildSystemPromptHandlesEmptyExpressions(t *testing.T) {
+	prompt := openai.BuildSystemPrompt(nil)
+	// Still emits an instruction line, just without a tag list.
+	if !strings.Contains(prompt, "[EXPR:") {
+		t.Fatalf("prompt should explain markers even with no tags\n---\n%s", prompt)
+	}
+}

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -1,6 +1,11 @@
 package openai_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -36,4 +41,100 @@ func TestBuildSystemPromptHandlesEmptyExpressions(t *testing.T) {
 	if !strings.Contains(prompt, "[EXPR:") {
 		t.Fatalf("prompt should explain markers even with no tags\n---\n%s", prompt)
 	}
+}
+
+func TestStreamReplyHappyPath(t *testing.T) {
+	// Upstream OpenAI-style SSE: deltas containing [EXPR:objection]...
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream got %s", r.URL.Path)
+		}
+		var body struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+			Stream bool `json:"stream"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("upstream decode: %v", err)
+		}
+		if !body.Stream || body.Model != "test-model" {
+			t.Fatalf("unexpected upstream body: %+v", body)
+		}
+		if len(body.Messages) != 2 || body.Messages[0].Role != "system" {
+			t.Fatalf("expected system+user messages, got %+v", body.Messages)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+
+		chunks := []string{
+			`{"choices":[{"delta":{"content":"[EXPR:objection]"}}]}`,
+			`{"choices":[{"delta":{"content":"异议！"}}]}`,
+			`{"choices":[{"delta":{"content":"[EXPR:polite]"}}]}`,
+			`{"choices":[{"delta":{"content":"再见。"}}]}`,
+			`[DONE]`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL, "sk-test", "test-model", 0.5, 256)
+	events, err := p.StreamReply(context.Background(), chat.Request{
+		ConversationID: "c1",
+		Message:        "你怎么看？",
+		Expressions: []chat.ExpressionInfo{
+			{ID: "neutral"},
+			{ID: "objection"},
+			{ID: "polite"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+
+	var got []chat.StreamEvent
+	for e := range events {
+		got = append(got, e)
+	}
+
+	mustFind := func(predicate func(chat.StreamEvent) bool, what string) {
+		t.Helper()
+		for _, e := range got {
+			if predicate(e) {
+				return
+			}
+		}
+		t.Fatalf("missing event: %s\nall: %+v", what, got)
+	}
+
+	mustFind(func(e chat.StreamEvent) bool { return e.Type == "RUN_STARTED" }, "RUN_STARTED")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "CUSTOM" && e.Name == "miles.pet.expression.requested" &&
+			e.Value["state"] == "thinking"
+	}, "thinking expression")
+	mustFind(func(e chat.StreamEvent) bool { return e.Type == "TEXT_MESSAGE_START" }, "TEXT_MESSAGE_START")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "CUSTOM" && e.Value["state"] == "speaking" && e.Value["expression"] == "objection"
+	}, "speaking objection expression")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "TEXT_MESSAGE_CONTENT" && e.Delta == "异议！"
+	}, "objection text")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "CUSTOM" && e.Value["state"] == "speaking" && e.Value["expression"] == "polite"
+	}, "speaking polite expression")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "TEXT_MESSAGE_CONTENT" && e.Delta == "再见。"
+	}, "polite text")
+	mustFind(func(e chat.StreamEvent) bool {
+		return e.Type == "CUSTOM" && e.Value["state"] == "idle" &&
+			e.Value["interruptHint"] == "afterCurrent"
+	}, "idle afterCurrent expression")
+	mustFind(func(e chat.StreamEvent) bool { return e.Type == "RUN_FINISHED" }, "RUN_FINISHED")
 }

--- a/apps/agent-core/internal/chat/provider.go
+++ b/apps/agent-core/internal/chat/provider.go
@@ -2,9 +2,19 @@ package chat
 
 import "context"
 
+// ExpressionInfo describes one expression tag the current skin makes available
+// to the model. Sent from Qt to the sidecar with each chat request.
+type ExpressionInfo struct {
+	ID            string   `json:"id"`
+	Label         string   `json:"label,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	AllowedStates []string `json:"allowedStates,omitempty"`
+}
+
 type Request struct {
-	ConversationID string
-	Message        string
+	ConversationID string           `json:"conversationId"`
+	Message        string           `json:"message"`
+	Expressions    []ExpressionInfo `json:"expressions,omitempty"`
 }
 
 type StreamEvent struct {

--- a/apps/desktop/CMakeLists.txt
+++ b/apps/desktop/CMakeLists.txt
@@ -126,15 +126,17 @@ set_target_properties(MilesEdgeworthDesktop PROPERTIES
 qt_finalize_executable(MilesEdgeworthDesktop)
 
 if(TARGET MilesAgentCore)
-    add_dependencies(MilesEdgeworthDesktop MilesAgentCore)
-    add_custom_command(
-        TARGET MilesEdgeworthDesktop
-        POST_BUILD
+    add_custom_target(CopyMilesAgentSidecar
+        ALL
+        DEPENDS MilesAgentCore
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+                "$<TARGET_FILE_DIR:MilesEdgeworthDesktop>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 "${MILES_AGENT_BINARY}"
                 "$<TARGET_FILE_DIR:MilesEdgeworthDesktop>/miles-agent${CMAKE_EXECUTABLE_SUFFIX}"
         VERBATIM
     )
+    add_dependencies(MilesEdgeworthDesktop CopyMilesAgentSidecar)
 endif()
 
 if(BUILD_TESTING)

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -160,6 +160,7 @@ void ChatController::cancelCurrentReply()
     }
 
     m_cancelled = true;
+    m_holdBuffer.clear();
     if (m_currentReply) {
         QNetworkReply *reply = m_currentReply;
         m_currentReply.clear();
@@ -256,15 +257,26 @@ void ChatController::appendAssistantDelta(const QString &delta)
         return;
     }
 
+    m_holdBuffer.append(delta);
+    flushHoldBuffer();
+}
+
+void ChatController::flushHoldBuffer()
+{
+    if (m_cancelled || m_holdBuffer.isEmpty()) {
+        return;
+    }
+
     if (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size()) {
         appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
         m_assistantMessageIndex = m_messages.size() - 1;
     }
 
     QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
-    message.insert(QStringLiteral("text"), message.value(QStringLiteral("text")).toString() + delta);
+    message.insert(QStringLiteral("text"), message.value(QStringLiteral("text")).toString() + m_holdBuffer);
     message.insert(QStringLiteral("pending"), true);
     m_messages[m_assistantMessageIndex] = message;
+    m_holdBuffer.clear();
     emit messagesChanged();
 }
 
@@ -351,6 +363,7 @@ void ChatController::finishCurrentReply()
     }
 
     m_assistantMessageIndex = -1;
+    m_holdBuffer.clear();
     m_currentReply.clear();
     setSending(false);
     setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
@@ -112,6 +113,30 @@ void ChatController::sendMessage(const QString &message)
     QJsonObject body;
     body.insert(QStringLiteral("conversationId"), QStringLiteral("default"));
     body.insert(QStringLiteral("message"), trimmed);
+    if (m_runtime != nullptr) {
+        QJsonArray expressionsArray;
+        const auto &manifestExpressions = m_runtime->manifest().expressions;
+        for (auto it = manifestExpressions.constBegin(); it != manifestExpressions.constEnd(); ++it) {
+            const auto &def = it.value();
+            QJsonObject entry;
+            entry.insert(QStringLiteral("id"), def.id);
+            if (!def.label.isEmpty()) {
+                entry.insert(QStringLiteral("label"), def.label);
+            }
+            if (!def.description.isEmpty()) {
+                entry.insert(QStringLiteral("description"), def.description);
+            }
+            if (!def.allowedStates.isEmpty()) {
+                QJsonArray allowedStates;
+                for (const QString &state : def.allowedStates) {
+                    allowedStates.append(state);
+                }
+                entry.insert(QStringLiteral("allowedStates"), allowedStates);
+            }
+            expressionsArray.append(entry);
+        }
+        body.insert(QStringLiteral("expressions"), expressionsArray);
+    }
 
     if (QCoreApplication::instance() == nullptr) {
         return;

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -97,8 +97,13 @@ public:
     // 与 PetRuntimeForeign / PetEventBridgeForeign / DesktopShellControllerForeign 保持一致，使用 inline static 就地定义。
     inline static ChatController *s_instance = nullptr;
 
-    static ChatController *create(QQmlEngine *, QJSEngine *)
+    static ChatController *create(QQmlEngine *, QJSEngine *scriptEngine)
     {
+        Q_ASSERT(s_instance != nullptr);
+        Q_ASSERT(scriptEngine->thread() == s_instance->thread());
+
+        // 单例对象由 main.cpp 持有，QML 引擎只借用，不负责 delete。
+        QJSEngine::setObjectOwnership(s_instance, QJSEngine::CppOwnership);
         return s_instance;
     }
 };

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -53,6 +53,7 @@ private:
     QVariantMap messageObject(const QString &role, const QString &text, bool pending, bool error) const;
     void appendMessage(const QVariantMap &message);
     void appendAssistantDelta(const QString &delta);
+    void flushHoldBuffer();
     void setSidecarReady(bool ready);
     void setSending(bool sending);
     void setStatusText(const QString &statusText);
@@ -72,6 +73,10 @@ private:
     QPointer<QNetworkReply> m_currentReply;
     ChatStreamEventParser m_parser;
     QVariantList m_messages;
+    // Phase 2.1 plumbing: accumulate streamed deltas before pushing to m_messages.
+    // Phase 2.3 will gate this buffer on PetRuntime animation boundaries; for now
+    // every Feed flushes immediately, matching the previous direct-append behavior.
+    QString m_holdBuffer;
     bool m_sidecarReady = false;
     bool m_sending = false;
     // 用户取消后，剩余 SSE chunks 必须被丢弃，否则会拼到新建的 assistant 消息里产生"幽灵回复"。

--- a/apps/desktop/src/main.cpp
+++ b/apps/desktop/src/main.cpp
@@ -6,6 +6,10 @@
 #include "pet/surface/PetSurfaceWindow.h"
 #include "skins/miles-edgeworth/MilesEdgeworthInteractions.h"
 
+#ifdef Q_OS_MACOS
+#include "platform/MacPetWindowBehavior.h"
+#endif
+
 #include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>
@@ -19,6 +23,9 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
     app.setQuitOnLastWindowClosed(false);
     QQuickStyle::setStyle("Basic");
+#ifdef Q_OS_MACOS
+    setMacApplicationDockVisible(false);
+#endif
 
     DesktopShellController shellController;
     DesktopShellControllerForeign::s_instance = &shellController;

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -103,5 +103,34 @@ int main()
     require(controller.messages().size() == messagesBeforeCancel,
             "stream content after cancel must not append a new assistant message");
 
+    // Hold buffer round-trip: feed a delta while the controller is in its default
+    // "immediate flush" mode (Phase 2.1 plumbing -- full GATED logic lands in 2.3).
+    PetRuntime hbRuntime;
+    ChatController hbController(&hbRuntime);
+
+    ChatStreamEvent hbStarted;
+    hbStarted.type = QStringLiteral("RUN_STARTED");
+    hbController.applyStreamEvent(hbStarted);
+
+    ChatStreamEvent hbStart;
+    hbStart.type = QStringLiteral("TEXT_MESSAGE_START");
+    hbStart.role = QStringLiteral("assistant");
+    hbController.applyStreamEvent(hbStart);
+
+    ChatStreamEvent hbContent;
+    hbContent.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+    hbContent.delta = QStringLiteral("片段一");
+    hbController.applyStreamEvent(hbContent);
+
+    require(hbController.messages().constFirst().toMap().value("text").toString()
+                == QStringLiteral("片段一"),
+            "hold buffer should flush content immediately in phase 2.1");
+
+    hbContent.delta = QStringLiteral("片段二");
+    hbController.applyStreamEvent(hbContent);
+    require(hbController.messages().constFirst().toMap().value("text").toString()
+                == QStringLiteral("片段一片段二"),
+            "subsequent deltas should append through the hold buffer");
+
     return 0;
 }

--- a/docs/v2/文档索引.md
+++ b/docs/v2/文档索引.md
@@ -35,6 +35,7 @@
 - [Phase 1 收尾与体验问题修复计划](阶段记录/Phase%201%20收尾与体验问题修复计划.md)：Phase 0.73 完成后发现的体验 bug（HitZone 错位、拖拽晃动、徽章尺寸）的根因分析、修复方案和进入 Phase 2 的前置条件。
 - [Phase 2 AI 聊天粗规划](阶段记录/Phase%202%20AI%20聊天粗规划.md)：Phase 2 的阶段编号解释、AI 聊天边界、Qt / Go sidecar 职责划分、子阶段拆分和 Phase 2.0 执行入口。
 - [Phase 2.0 AI Chat MVP 骨架](阶段记录/Phase%202.0%20AI%20Chat%20MVP%20骨架.md)：Phase 2.0 的 mock provider、Go sidecar、Qt ChatController、QML ChatWindow 和表达联动验收记录。
+- [Phase 2.1 OpenAI-compatible Provider](阶段记录/Phase%202.1%20OpenAI-compatible%20Provider.md)：Phase 2.1 的 OpenAI-compatible provider 接入、`[EXPR:tag]` 标记协议骨架、`Request` JSON tag 升级、hold buffer 雏形和服务端 hardening。
 
 ## 维护规则
 

--- a/docs/v2/阶段记录/Phase 2.1 OpenAI-compatible Provider.md
+++ b/docs/v2/阶段记录/Phase 2.1 OpenAI-compatible Provider.md
@@ -1,0 +1,40 @@
+# Phase 2.1 OpenAI-compatible Provider
+
+本文记录 Phase 2.1 的实现范围、验收方式和后续限制。Phase 2.1 接入真实 OpenAI-compatible Chat Completions provider，引入 `[EXPR:tag]` 标记协议骨架，并为 Phase 2.3 的完整状态机准备 hold buffer 雏形。
+
+参考设计：`docs/v2/设计方案/AI 聊天动画编排设计.md` §11 Phase 2.1 行。
+
+## 完成范围
+
+- 新增 `internal/chat/config`：从 `MILES_PROVIDER_BASE_URL` / `MILES_PROVIDER_API_KEY` / `MILES_PROVIDER_MODEL` / `MILES_PROVIDER_TEMPERATURE` / `MILES_PROVIDER_MAX_TOKENS` 环境变量读取 provider 配置；`Enabled()` 判断是否齐备。
+- 新增 `internal/chat/expression`：`[EXPR:tag]` 流式 token 解析器，支持跨 chunk 边界、未知 tag 降级到 `neutral`、`Flush` 时残留作为 text 输出。
+- 新增 `internal/chat/openai`：OpenAI-compatible provider 适配器，POST `/v1/chat/completions` with stream=true，构建带 expression 清单的 system prompt，把 upstream SSE delta 通过 expression parser 转换为我们的 AG-UI envelope。
+- `main.go` 根据 `config.Enabled()` 选择 provider：齐备时是 openai-compatible，否则 fallback 到 mock 并在 `/health` 标 `provider: "mock-fallback"`。
+- `Request` 结构增加显式 JSON tag 和 `Expressions []ExpressionInfo` 字段。
+- `api.Server` 接受 provider label，加 `http.MaxBytesReader`（1MB 限制），共享常量 `DefaultListenAddr = "127.0.0.1:39710"`。
+- Qt `ChatController` 在 `sendMessage` 时携带当前皮肤 `manifest.expressions`。
+- Qt `ChatController` 新增 `m_holdBuffer` / `flushHoldBuffer`：所有 `TEXT_MESSAGE_CONTENT` 通过 hold buffer 入 UI，当前实现为"立即 flush"，为 Phase 2.3 状态机预留位置。
+
+## 验收命令
+
+```bash
+python3 tests/check_phase_2_0_ai_chat_mvp.py
+python3 tests/check_phase_2_1_provider.py
+(cd apps/agent-core && go test ./...)
+cmake --build build --target MilesEdgeworthDesktop
+ctest --test-dir build -R "chat_stream_event_parser_smoke|chat_controller_smoke|check_phase_2_0_ai_chat_mvp|check_phase_2_1_provider" --output-on-failure
+```
+
+## 当前限制
+
+- ChatController 状态机仍是"流过即显示"，没有按 expression 切换 gate 文字。Phase 2.3 落地完整状态机和字符速率限制器。
+- 配置只能通过环境变量；图形化设置面板和 Keychain 在 Phase 2.2。
+- 会话历史不持久化；persona prompt 是最小版本。
+- expression marker 解析放在 sidecar，Qt 仍然只接收已解析的事件。
+- Provider 端口仍硬编码在 `DefaultListenAddr` / `ChatController.cpp`，未来如需动态端口由 sidecar 通过 stdout 上报。
+
+## 后续入口
+
+- Phase 2.2：设置 UI + API Key 安全存储。
+- Phase 2.3：会话历史、完整 persona prompt、ChatController 状态机、字符速率限制器。
+- Phase 2.4：Phased 动画与 `requestCleanFinishAndNotify` / `requestBoundaryAndNotify`。

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -51,6 +51,11 @@ def main() -> int:
 
     for token in ["Network", "QuickControls2", "ChatController.cpp", "ChatStreamEvent.cpp", "ChatWindow.qml"]:
         require(token in desktop_cmake, f"desktop CMake missing {token}")
+    require(
+        "CopyMilesAgentSidecar" in desktop_cmake
+        and "add_dependencies(MilesEdgeworthDesktop CopyMilesAgentSidecar)" in desktop_cmake,
+        "desktop CMake must copy miles-agent through a sidecar target so provider-only rebuilds update the app bundle",
+    )
 
     require("go 1.22" in go_mod, "agent-core go.mod must target Go 1.22")
     require("find_program(GO_EXECUTABLE go)" in agent_cmake, "agent-core CMake must find go")

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -93,6 +93,10 @@ def main() -> int:
     require("background: Rectangle" in chat_qml, "ChatWindow input and buttons must use explicit backgrounds")
     require("contentItem: Text" in chat_qml, "ChatWindow buttons must use readable explicit text content")
     require("ChatControllerForeign::s_instance" in main_cpp, "main must expose ChatController singleton")
+    require(
+        "QJSEngine::setObjectOwnership(s_instance, QJSEngine::CppOwnership)" in controller_h,
+        "ChatController singleton must keep C++ ownership so QQmlEngine does not delete the stack instance",
+    )
     require("#include <QQuickStyle>" in main_cpp, "main must include QQuickStyle for chat controls styling")
     require(
         'QQuickStyle::setStyle("Basic")' in main_cpp,
@@ -114,6 +118,10 @@ def main() -> int:
         "NSApplicationActivationPolicyRegular" in mac_behavior_mm
         and "NSApplicationActivationPolicyAccessory" in mac_behavior_mm,
         "macOS chat Dock control must switch between Regular and Accessory activation policies",
+    )
+    require(
+        "setMacApplicationDockVisible(false)" in main_cpp,
+        "main must start macOS in accessory mode until the chat window is visible",
     )
     require("loadFromModule(\"MilesEdgeworth\", \"ChatWindow\")" in main_cpp, "main must load ChatWindow QML")
     require("聊天" in menu_cpp, "native pet context menu must include chat entry")

--- a/tests/check_phase_2_1_provider.py
+++ b/tests/check_phase_2_1_provider.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Check the Phase 2.1 OpenAI-compatible provider contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    file_path = ROOT / path
+    if not file_path.exists():
+        raise AssertionError(f"missing file: {path}")
+    return file_path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    config_go = read("apps/agent-core/internal/chat/config/config.go")
+    config_test = read("apps/agent-core/internal/chat/config/config_test.go")
+    parser_go = read("apps/agent-core/internal/chat/expression/parser.go")
+    parser_test = read("apps/agent-core/internal/chat/expression/parser_test.go")
+    openai_go = read("apps/agent-core/internal/chat/openai/provider.go")
+    openai_test = read("apps/agent-core/internal/chat/openai/provider_test.go")
+    main_go = read("apps/agent-core/cmd/miles-agent/main.go")
+    server_go = read("apps/agent-core/internal/api/server.go")
+    provider_go = read("apps/agent-core/internal/chat/provider.go")
+    controller_h = read("apps/desktop/src/chat/ChatController.h")
+    controller_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    controller_smoke = read("apps/desktop/tests/chat_controller_smoke.cpp")
+    root_cmake = read("CMakeLists.txt")
+    index_doc = read("docs/v2/文档索引.md")
+    phase_record = read("docs/v2/阶段记录/Phase 2.1 OpenAI-compatible Provider.md")
+
+    require("MILES_PROVIDER_BASE_URL" in config_go, "config must read MILES_PROVIDER_BASE_URL")
+    require("MILES_PROVIDER_API_KEY" in config_go, "config must read MILES_PROVIDER_API_KEY")
+    require("MILES_PROVIDER_MODEL" in config_go, "config must read MILES_PROVIDER_MODEL")
+    require("func (c ProviderConfig) Enabled()" in config_go, "config must expose Enabled receiver method")
+    require("TestFromEnv" in config_test, "config tests must cover FromEnv")
+
+    require("type Parser struct" in parser_go, "expression parser must be a struct type")
+    require("Feed(chunk string)" in parser_go, "parser must expose Feed")
+    require("Flush()" in parser_go, "parser must expose Flush")
+    require("OnText" in parser_go and "OnExpression" in parser_go, "parser callbacks must be exposed")
+    require("[EXPR:" in parser_go, "parser must reference the EXPR marker syntax")
+    require("TestParserCrossChunk" in parser_test, "parser tests must cover cross-chunk markers")
+    require("TestParserUnknownTag" in parser_test, "parser tests must cover unknown tags")
+
+    require("/v1/chat/completions" in openai_go, "openai provider must POST to /v1/chat/completions")
+    require("Bearer " in openai_go, "openai provider must send Bearer token")
+    require("buildSystemPrompt" in openai_go, "openai provider must assemble a system prompt")
+    require("expression.NewParser" in openai_go, "openai provider must use the expression parser")
+    require("httptest.NewServer" in openai_test, "openai provider tests must use httptest")
+
+    require("openai.NewProvider" in main_go, "main must construct openai provider when configured")
+    require("mock-fallback" in main_go, "main must label provider as mock-fallback when config missing")
+
+    require("http.MaxBytesReader" in server_go, "server must enforce max request body size")
+    require("const DefaultListenAddr" in server_go or "DefaultListenAddr =" in server_go,
+            "server must expose a shared default listen address constant")
+
+    require('json:"conversationId"' in provider_go, "Request must use json tag conversationId")
+    require('json:"message"' in provider_go, "Request must use json tag message")
+    require('json:"expressions,omitempty"' in provider_go, "Request must carry expressions list")
+    require("type ExpressionInfo struct" in provider_go, "ExpressionInfo struct must exist")
+
+    require("m_holdBuffer" in controller_h, "ChatController must declare a hold buffer member")
+    require("flushHoldBuffer" in controller_h, "ChatController must declare flushHoldBuffer")
+    require("m_holdBuffer" in controller_cpp, "ChatController.cpp must use the hold buffer")
+    require('"expressions"' in controller_cpp, "ChatController must include expressions field in request body")
+
+    require("hold buffer" in controller_smoke.lower() or "m_holdBuffer" in controller_smoke,
+            "smoke test must cover the hold buffer path")
+
+    require("check_phase_2_1_provider" in root_cmake, "root CMake must register Phase 2.1 contract check")
+    require("Phase 2.1" in phase_record, "phase 2.1 record must exist")
+    require("Phase 2.1" in index_doc, "doc index must link Phase 2.1 record")
+
+    print("phase 2.1 provider contract ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 变更摘要

- 新增 OpenAI-compatible Chat Completions provider，支持环境变量配置、mock fallback、上游 SSE 到内部事件流的转换。
- 新增 `[EXPR:tag]` 流式解析器，把模型输出中的表达标记拆成 `miles.pet.expression.requested` 事件和纯文本 delta。
- Qt `ChatController` 请求体携带当前皮肤 expressions，并加入 Phase 2.3 状态机要复用的 hold buffer 雏形。
- 补充 Phase 2.1 contract、阶段记录和文档索引，服务端增加 provider label、请求体大小限制和共享监听地址常量。

## 验证

- `python3 tests/check_phase_2_0_ai_chat_mvp.py`
- `python3 tests/check_phase_2_1_provider.py`
- `(cd apps/agent-core && go test ./...)`
- `cmake --build build --target MilesEdgeworthDesktop`
- `ctest --test-dir build -R "chat_stream_event_parser_smoke|chat_controller_smoke|check_phase_2_0_ai_chat_mvp|check_phase_2_1_provider" --output-on-failure`
- 本地 mock fallback smoke：`GET /health` 返回 `provider=mock-fallback`，`POST /v1/chat/messages` 返回完整 SSE 并以 `RUN_FINISHED` 结束。

## 说明

真实 provider smoke 需要用户本机配置 `MILES_PROVIDER_BASE_URL`、`MILES_PROVIDER_API_KEY`、`MILES_PROVIDER_MODEL`，本 PR 不在自动测试中访问外部 API。
