### PR TITLE
Phase 2.3.1：动画文字同步与日志规范

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,5 +593,13 @@ if(BUILD_TESTING)
                     ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_3_1_animation_sync.py
         )
 
+        # Logging standard check: keeps Qt + Go logging categories, env vars,
+        # payload safety, and sidecar stderr forwarding aligned with docs/v2/设计方案/日志规范设计.md.
+        add_test(
+            NAME check_logging_standard
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_logging_standard.py
+        )
+
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,5 +585,13 @@ if(BUILD_TESTING)
                     ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_2_settings.py
         )
 
+        # Phase 2.3.1 的动画-文字同步检查：守住 ChatController 状态机、
+        # 字符速率限制器和 PetRuntime 的边界通知 API。
+        add_test(
+            NAME check_phase_2_3_1_animation_sync
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_3_1_animation_sync.py
+        )
+
     endif()
 endif()

--- a/apps/agent-core/cmd/miles-agent/main.go
+++ b/apps/agent-core/cmd/miles-agent/main.go
@@ -21,6 +21,12 @@ func main() {
 	flag.Parse()
 
 	cfg := config.FromEnv()
+	debugChat := os.Getenv("MILES_DEBUG_CHAT") != ""
+	openai.SetDebugLogging(debugChat)
+	if debugChat {
+		log.Printf("debug chat diagnostics enabled")
+	}
+
 	var provider chat.Provider
 	label := "mock-fallback"
 	if cfg.Enabled() {

--- a/apps/agent-core/cmd/miles-agent/main.go
+++ b/apps/agent-core/cmd/miles-agent/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,28 +13,26 @@ import (
 	"milesedgeworth/agent-core/internal/chat"
 	"milesedgeworth/agent-core/internal/chat/config"
 	"milesedgeworth/agent-core/internal/chat/openai"
+	"milesedgeworth/agent-core/internal/mileslog"
 )
+
+var logger = mileslog.New("MILES.SIDECAR")
 
 func main() {
 	addr := flag.String("addr", api.DefaultListenAddr, "listen address")
 	flag.Parse()
 
 	cfg := config.FromEnv()
-	debugChat := os.Getenv("MILES_DEBUG_CHAT") != ""
-	openai.SetDebugLogging(debugChat)
-	if debugChat {
-		log.Printf("debug chat diagnostics enabled")
-	}
 
 	var provider chat.Provider
 	label := "mock-fallback"
 	if cfg.Enabled() {
 		provider = openai.NewProvider(cfg.BaseURL, cfg.APIKey, cfg.Model, cfg.Temperature, cfg.MaxTokens)
 		label = "openai-compatible"
-		log.Printf("provider: openai-compatible model=%s", cfg.Model)
+		logger.Info("provider selected", "provider", "openai-compatible", "model", cfg.Model)
 	} else {
 		provider = chat.NewMockProvider(35 * time.Millisecond)
-		log.Printf("provider: mock-fallback (set MILES_PROVIDER_BASE_URL, MILES_PROVIDER_API_KEY, MILES_PROVIDER_MODEL to use a real provider)")
+		logger.Info("provider selected", "provider", "mock-fallback")
 	}
 
 	server := &http.Server{
@@ -45,7 +42,7 @@ func main() {
 
 	errs := make(chan error, 1)
 	go func() {
-		log.Printf("miles-agent listening on %s", *addr)
+		logger.Info("server listening", "addr", *addr)
 		errs <- server.ListenAndServe()
 	}()
 
@@ -54,15 +51,17 @@ func main() {
 
 	select {
 	case sig := <-signals:
-		log.Printf("received %s, shutting down", sig)
+		logger.Info("shutdown requested", "signal", sig.String())
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := server.Shutdown(ctx); err != nil {
-			log.Fatalf("shutdown failed: %v", err)
+			logger.Error("shutdown failed", "error", err)
+			os.Exit(1)
 		}
 	case err := <-errs:
 		if err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server failed: %v", err)
+			logger.Error("server failed", "error", err)
+			os.Exit(1)
 		}
 	}
 }

--- a/apps/agent-core/internal/api/server.go
+++ b/apps/agent-core/internal/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 
 	"milesedgeworth/agent-core/internal/chat"
@@ -45,6 +46,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":       true,
+		"pid":      os.Getpid(),
 		"provider": s.providerLabel,
 		"service":  "miles-agent",
 	})

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,6 +15,7 @@ import (
 
 	"milesedgeworth/agent-core/internal/chat"
 	"milesedgeworth/agent-core/internal/chat/expression"
+	"milesedgeworth/agent-core/internal/mileslog"
 )
 
 type Provider struct {
@@ -27,17 +27,7 @@ type Provider struct {
 	httpClient  *http.Client
 }
 
-var debugLoggingEnabled bool
-
-func SetDebugLogging(enabled bool) {
-	debugLoggingEnabled = enabled
-}
-
-func debugf(format string, args ...any) {
-	if debugLoggingEnabled {
-		log.Printf("debug chat.openai: "+format, args...)
-	}
-}
+var logger = mileslog.New("MILES.CHAT.PROVIDER")
 
 func NewProvider(baseURL, apiKey, model string, temperature float64, maxTokens int) *Provider {
 	return &Provider{
@@ -145,8 +135,11 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 		close(events)
 		return events, err
 	}
-	debugf("request prepared model=%s endpoint=%s expressions=%d message_len=%d",
-		p.model, sanitizeEndpoint(p.baseURL), len(req.Expressions), len([]rune(req.Message)))
+	logger.Debug("request prepared",
+		"model", p.model,
+		"endpoint", sanitizeEndpoint(p.baseURL),
+		"expressions", len(req.Expressions),
+		"messageLen", len([]rune(req.Message)))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		p.baseURL, bytes.NewReader(encoded))
@@ -182,7 +175,7 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 	for _, e := range req.Expressions {
 		knownTags = append(knownTags, e.ID)
 	}
-	debugf("stream started known_tags=%s", strings.Join(knownTags, ","))
+	logger.Debug("stream started", "knownTags", strings.Join(knownTags, ","))
 
 	go p.pipe(ctx, resp, events, knownTags)
 	return events, nil
@@ -248,7 +241,9 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		func(text string) {
 			if !sawFirstSpeaking {
 				sawFirstSpeaking = true
-				debugf("no leading expression before text; fallback expression=neutral text_len=%d", len([]rune(text)))
+				logger.Debug("fallback expression inserted",
+					"expression", "neutral",
+					"textLen", len([]rune(text)))
 				send(ctx, events, chat.StreamEvent{
 					Type:  "CUSTOM",
 					Name:  "miles.pet.expression.requested",
@@ -256,7 +251,7 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 					Value: map[string]any{"state": "speaking", "expression": "neutral"},
 				})
 			}
-			debugf("text chunk parsed len=%d", len([]rune(text)))
+			logger.Debug("text chunk parsed", "len", len([]rune(text)))
 			send(ctx, events, chat.StreamEvent{
 				Type:      "TEXT_MESSAGE_CONTENT",
 				RunID:     runID,
@@ -266,7 +261,7 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		},
 		func(tag string) {
 			sawFirstSpeaking = true
-			debugf("expression tag parsed tag=%s", tag)
+			logger.Debug("expression tag parsed", "tag", tag)
 			send(ctx, events, chat.StreamEvent{
 				Type:  "CUSTOM",
 				Name:  "miles.pet.expression.requested",
@@ -289,17 +284,24 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		}
 		var chunk chatCompletionStreamChunk
 		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			logger.Warn("malformed provider chunk skipped", "error", err)
+			if mileslog.PayloadLoggingEnabled() {
+				logger.Debug("malformed provider payload", "payload", payload)
+			}
 			continue
 		}
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != "" {
-				debugf("provider delta received len=%d", len([]rune(choice.Delta.Content)))
+				logger.Debug("provider delta received", "len", len([]rune(choice.Delta.Content)))
+				if mileslog.PayloadLoggingEnabled() {
+					logger.Debug("provider delta payload", "text", choice.Delta.Content)
+				}
 				parser.Feed(choice.Delta.Content)
 			}
 		}
 	}
 	parser.Flush()
-	debugf("stream finished")
+	logger.Debug("stream finished")
 
 	send(ctx, events, chat.StreamEvent{
 		Type:      "TEXT_MESSAGE_END",

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,6 +25,18 @@ type Provider struct {
 	temperature float64
 	maxTokens   int
 	httpClient  *http.Client
+}
+
+var debugLoggingEnabled bool
+
+func SetDebugLogging(enabled bool) {
+	debugLoggingEnabled = enabled
+}
+
+func debugf(format string, args ...any) {
+	if debugLoggingEnabled {
+		log.Printf("debug chat.openai: "+format, args...)
+	}
 }
 
 func NewProvider(baseURL, apiKey, model string, temperature float64, maxTokens int) *Provider {
@@ -132,6 +145,8 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 		close(events)
 		return events, err
 	}
+	debugf("request prepared model=%s endpoint=%s expressions=%d message_len=%d",
+		p.model, sanitizeEndpoint(p.baseURL), len(req.Expressions), len([]rune(req.Message)))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		p.baseURL, bytes.NewReader(encoded))
@@ -167,6 +182,7 @@ func (p *Provider) StreamReply(ctx context.Context, req chat.Request) (<-chan ch
 	for _, e := range req.Expressions {
 		knownTags = append(knownTags, e.ID)
 	}
+	debugf("stream started known_tags=%s", strings.Join(knownTags, ","))
 
 	go p.pipe(ctx, resp, events, knownTags)
 	return events, nil
@@ -232,6 +248,7 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		func(text string) {
 			if !sawFirstSpeaking {
 				sawFirstSpeaking = true
+				debugf("no leading expression before text; fallback expression=neutral text_len=%d", len([]rune(text)))
 				send(ctx, events, chat.StreamEvent{
 					Type:  "CUSTOM",
 					Name:  "miles.pet.expression.requested",
@@ -239,6 +256,7 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 					Value: map[string]any{"state": "speaking", "expression": "neutral"},
 				})
 			}
+			debugf("text chunk parsed len=%d", len([]rune(text)))
 			send(ctx, events, chat.StreamEvent{
 				Type:      "TEXT_MESSAGE_CONTENT",
 				RunID:     runID,
@@ -248,6 +266,7 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		},
 		func(tag string) {
 			sawFirstSpeaking = true
+			debugf("expression tag parsed tag=%s", tag)
 			send(ctx, events, chat.StreamEvent{
 				Type:  "CUSTOM",
 				Name:  "miles.pet.expression.requested",
@@ -274,11 +293,13 @@ func (p *Provider) pipe(ctx context.Context, resp *http.Response, events chan<- 
 		}
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != "" {
+				debugf("provider delta received len=%d", len([]rune(choice.Delta.Content)))
 				parser.Feed(choice.Delta.Content)
 			}
 		}
 	}
 	parser.Flush()
+	debugf("stream finished")
 
 	send(ctx, events, chat.StreamEvent{
 		Type:      "TEXT_MESSAGE_END",

--- a/apps/agent-core/internal/chat/openai/provider.go
+++ b/apps/agent-core/internal/chat/openai/provider.go
@@ -68,7 +68,9 @@ func BuildSystemPrompt(expressions []chat.ExpressionInfo) string {
 
 func buildSystemPrompt(expressions []chat.ExpressionInfo) string {
 	var sb strings.Builder
-	sb.WriteString("你是 Miles Edgeworth 桌宠助手。回复时在每段文字开头用 [EXPR:标签名] 标记当前表达。")
+	sb.WriteString("你是 Miles Edgeworth 桌宠助手。回复时在每段文字开头用 [EXPR:id] 标记当前表达。")
+	sb.WriteString("只能使用方括号中列出的 id 原文，不要翻译 id，也不要使用中文 label。")
+	sb.WriteString("例如使用 [EXPR:objection]，不要输出 [EXPR:异议]。")
 	sb.WriteString("情绪延续时不重复标记。回复的第一段文字必须有标记。\n\n")
 	if len(expressions) == 0 {
 		return sb.String()

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -317,3 +317,31 @@ func TestStreamReplySkipsMalformedChunks(t *testing.T) {
 		t.Fatal("expected polite expression after malformed chunk was skipped")
 	}
 }
+
+func TestPayloadLoggingFlagDoesNotAffectStreamEvents(t *testing.T) {
+	t.Setenv("MILES_LOG_PAYLOADS", "1")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"[EXPR:polite]secret text\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL, "sk-test", "any", 0.7, 128)
+	events, err := p.StreamReply(context.Background(), chat.Request{
+		Message:     "hi",
+		Expressions: []chat.ExpressionInfo{{ID: "polite"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	seenText := false
+	for event := range events {
+		if event.Type == "TEXT_MESSAGE_CONTENT" && event.Delta == "secret text" {
+			seenText = true
+		}
+	}
+	if !seenText {
+		t.Fatal("payload logging flag must not change stream parsing")
+	}
+}

--- a/apps/agent-core/internal/chat/openai/provider_test.go
+++ b/apps/agent-core/internal/chat/openai/provider_test.go
@@ -28,6 +28,9 @@ func TestBuildSystemPromptIncludesAllExpressions(t *testing.T) {
 		"objection",
 		"强烈反驳",
 		"polite",
+		"只能使用方括号中列出的 id 原文",
+		"[EXPR:objection]",
+		"不要输出 [EXPR:异议]",
 	} {
 		if !strings.Contains(prompt, expect) {
 			t.Fatalf("prompt missing %q\n---\n%s", expect, prompt)

--- a/apps/agent-core/internal/mileslog/mileslog.go
+++ b/apps/agent-core/internal/mileslog/mileslog.go
@@ -24,6 +24,7 @@ type handler struct {
 	sinks []sink
 	level slog.Level
 	attrs []slog.Attr
+	group []string
 }
 
 var (
@@ -69,6 +70,8 @@ func defaultSinks() []sink {
 	if path := strings.TrimSpace(os.Getenv("MILES_LOG_FILE")); path != "" {
 		if file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
 			sinks = append(sinks, sink{writer: file, includeDate: true})
+		} else {
+			fmt.Fprintf(os.Stderr, "mileslog: open log file %q: %v\n", path, err)
 		}
 	}
 	return sinks
@@ -90,16 +93,20 @@ func (h *handler) Handle(_ context.Context, record slog.Record) error {
 	attrs := make([]slog.Attr, 0, len(h.attrs)+record.NumAttrs())
 	attrs = append(attrs, h.attrs...)
 	record.Attrs(func(attr slog.Attr) bool {
-		attrs = append(attrs, attr)
+		attrs = appendAttr(attrs, h.group, attr)
 		return true
 	})
 
 	category := "MILES.APP"
+	categoryFound := false
 	filtered := attrs[:0]
 	for _, attr := range attrs {
 		if attr.Key == "category" {
-			if value := strings.TrimSpace(attr.Value.String()); value != "" {
-				category = strings.ToUpper(value)
+			if !categoryFound {
+				categoryFound = true
+				if value := strings.TrimSpace(attr.Value.String()); value != "" {
+					category = strings.ToUpper(value)
+				}
 			}
 			continue
 		}
@@ -120,12 +127,60 @@ func (h *handler) Handle(_ context.Context, record slog.Record) error {
 
 func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	next := *h
-	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	next.attrs = append([]slog.Attr{}, h.attrs...)
+	next.attrs = appendAttrs(next.attrs, h.group, attrs)
 	return &next
 }
 
-func (h *handler) WithGroup(_ string) slog.Handler {
-	return h
+func (h *handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	next := *h
+	next.group = append(append([]string{}, h.group...), name)
+	return &next
+}
+
+func appendAttrs(dst []slog.Attr, groups []string, attrs []slog.Attr) []slog.Attr {
+	for _, attr := range attrs {
+		dst = appendAttr(dst, groups, attr)
+	}
+	return dst
+}
+
+func appendAttr(dst []slog.Attr, groups []string, attr slog.Attr) []slog.Attr {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return dst
+	}
+
+	if attr.Value.Kind() == slog.KindGroup {
+		groupAttrs := attr.Value.Group()
+		if len(groupAttrs) == 0 {
+			return dst
+		}
+		nextGroups := groups
+		if attr.Key != "" {
+			nextGroups = append(append([]string{}, groups...), attr.Key)
+		}
+		return appendAttrs(dst, nextGroups, groupAttrs)
+	}
+
+	if attr.Key == "" {
+		return dst
+	}
+	attr.Key = qualifyKey(groups, attr.Key)
+	return append(dst, attr)
+}
+
+func qualifyKey(groups []string, key string) string {
+	if len(groups) == 0 {
+		return key
+	}
+	parts := make([]string, 0, len(groups)+1)
+	parts = append(parts, groups...)
+	parts = append(parts, key)
+	return strings.Join(parts, ".")
 }
 
 func formatLine(t time.Time, level slog.Level, category string, message string, attrs []slog.Attr, source string, includeDate bool) string {

--- a/apps/agent-core/internal/mileslog/mileslog.go
+++ b/apps/agent-core/internal/mileslog/mileslog.go
@@ -1,0 +1,192 @@
+package mileslog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type sink struct {
+	writer      io.Writer
+	includeDate bool
+}
+
+type handler struct {
+	slog.Handler
+	mu    *sync.Mutex
+	sinks []sink
+	level slog.Level
+	attrs []slog.Attr
+}
+
+var (
+	defaultLogger *slog.Logger
+	payloads      bool
+)
+
+func init() {
+	payloads = payloadLoggingEnabledFromEnv()
+	defaultLogger = slog.New(newHandler(defaultSinks(), parseLevel(os.Getenv("MILES_LOG_LEVEL"))))
+}
+
+func New(category string) *slog.Logger {
+	if defaultLogger == nil {
+		defaultLogger = slog.New(newHandler(defaultSinks(), slog.LevelInfo))
+	}
+	return defaultLogger.With("category", strings.ToUpper(strings.TrimSpace(category)))
+}
+
+func PayloadLoggingEnabled() bool {
+	return payloads
+}
+
+func payloadLoggingEnabledFromEnv() bool {
+	return os.Getenv("MILES_LOG_PAYLOADS") == "1"
+}
+
+func parseLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func defaultSinks() []sink {
+	sinks := []sink{{writer: os.Stderr, includeDate: false}}
+	if path := strings.TrimSpace(os.Getenv("MILES_LOG_FILE")); path != "" {
+		if file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+			sinks = append(sinks, sink{writer: file, includeDate: true})
+		}
+	}
+	return sinks
+}
+
+func newHandler(sinks []sink, level slog.Level) *handler {
+	return &handler{
+		Handler: slog.NewTextHandler(io.Discard, nil),
+		mu:      &sync.Mutex{},
+		sinks:   sinks,
+		level:   level,
+	}
+}
+
+func (h *handler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *handler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make([]slog.Attr, 0, len(h.attrs)+record.NumAttrs())
+	attrs = append(attrs, h.attrs...)
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+
+	category := "MILES.APP"
+	filtered := attrs[:0]
+	for _, attr := range attrs {
+		if attr.Key == "category" {
+			if value := strings.TrimSpace(attr.Value.String()); value != "" {
+				category = strings.ToUpper(value)
+			}
+			continue
+		}
+		filtered = append(filtered, attr)
+	}
+
+	source := sourceLocation(record.PC)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, sink := range h.sinks {
+		line := formatLine(record.Time, record.Level, category, record.Message, filtered, source, sink.includeDate)
+		if _, err := io.WriteString(sink.writer, line+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := *h
+	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &next
+}
+
+func formatLine(t time.Time, level slog.Level, category string, message string, attrs []slog.Attr, source string, includeDate bool) string {
+	if t.IsZero() {
+		t = time.Now()
+	}
+	layout := "15:04:05.000"
+	if includeDate {
+		layout = "2006-01-02 15:04:05.000"
+	}
+	parts := []string{
+		t.Format(layout),
+		paddedLevel(level),
+		"[" + category + "]",
+		message,
+	}
+	for _, attr := range attrs {
+		parts = append(parts, attr.Key+"="+attrValueString(attr.Value))
+	}
+	if source != "" {
+		parts = append(parts, "["+source+"]")
+	}
+	return strings.Join(parts, " ")
+}
+
+func paddedLevel(level slog.Level) string {
+	switch {
+	case level <= slog.LevelDebug:
+		return "DEBUG"
+	case level < slog.LevelWarn:
+		return "INFO "
+	case level < slog.LevelError:
+		return "WARN "
+	default:
+		return "ERROR"
+	}
+}
+
+func attrValueString(value slog.Value) string {
+	var text string
+	switch value.Kind() {
+	case slog.KindString:
+		text = value.String()
+	default:
+		text = fmt.Sprint(value.Any())
+	}
+	if text == "" {
+		return `""`
+	}
+	if strings.ContainsAny(text, " \t\r\n") {
+		return strconv.Quote(text)
+	}
+	return text
+}
+
+func sourceLocation(pc uintptr) string {
+	if pc == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames([]uintptr{pc})
+	frame, _ := frames.Next()
+	if frame.File == "" {
+		return ""
+	}
+	return filepath.Base(frame.File) + ":" + strconv.Itoa(frame.Line)
+}

--- a/apps/agent-core/internal/mileslog/mileslog.go
+++ b/apps/agent-core/internal/mileslog/mileslog.go
@@ -20,7 +20,6 @@ type sink struct {
 }
 
 type handler struct {
-	slog.Handler
 	mu    *sync.Mutex
 	sinks []sink
 	level slog.Level
@@ -77,10 +76,9 @@ func defaultSinks() []sink {
 
 func newHandler(sinks []sink, level slog.Level) *handler {
 	return &handler{
-		Handler: slog.NewTextHandler(io.Discard, nil),
-		mu:      &sync.Mutex{},
-		sinks:   sinks,
-		level:   level,
+		mu:    &sync.Mutex{},
+		sinks: sinks,
+		level: level,
 	}
 }
 
@@ -124,6 +122,10 @@ func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	next := *h
 	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
 	return &next
+}
+
+func (h *handler) WithGroup(_ string) slog.Handler {
+	return h
 }
 
 func formatLine(t time.Time, level slog.Level, category string, message string, attrs []slog.Attr, source string, includeDate bool) string {

--- a/apps/agent-core/internal/mileslog/mileslog_test.go
+++ b/apps/agent-core/internal/mileslog/mileslog_test.go
@@ -83,3 +83,74 @@ func TestEnabledHonorsLevel(t *testing.T) {
 		t.Fatal("error should be enabled at warn level")
 	}
 }
+
+func TestHandlerQualifiesAttrsAddedAfterWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST").WithGroup("request").With("model", "x").WithGroup("body")
+
+	logger.Info("grouped line", "tokens", 12)
+
+	got := buf.String()
+	for _, want := range []string{
+		"request.model=x",
+		"request.body.tokens=12",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("grouped log missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestHandlerFlattensSlogGroupAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Info("group attr", slog.Group("request", "model", "x", slog.Group("usage", "tokens", 12)))
+
+	got := buf.String()
+	for _, want := range []string{
+		"request.model=x",
+		"request.usage.tokens=12",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("flattened group log missing %q in %q", want, got)
+		}
+	}
+}
+
+type redactedValue string
+
+func (v redactedValue) LogValue() slog.Value {
+	return slog.StringValue("redacted:" + string(v))
+}
+
+func TestHandlerResolvesLogValuerAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Info("resolved attr", "payload", redactedValue("token"))
+
+	got := buf.String()
+	if !strings.Contains(got, "payload=redacted:token") {
+		t.Fatalf("log valuer attr should be resolved, got %q", got)
+	}
+}
+
+func TestPerCallCategoryDoesNotOverrideLoggerCategory(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.FIXED")
+
+	logger.Info("category attempt", "category", "MILES.CALL")
+
+	got := buf.String()
+	if !strings.Contains(got, "[MILES.FIXED]") {
+		t.Fatalf("logger category should be preserved, got %q", got)
+	}
+	if strings.Contains(got, "[MILES.CALL]") {
+		t.Fatalf("per-call category should not override logger category: %q", got)
+	}
+}

--- a/apps/agent-core/internal/mileslog/mileslog_test.go
+++ b/apps/agent-core/internal/mileslog/mileslog_test.go
@@ -1,0 +1,85 @@
+package mileslog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestHandlerFormatsCategoryMessageAttrsAndSource(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelDebug)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Debug("stream event", "deltaLen", 3, "state", "speaking")
+
+	got := buf.String()
+	for _, want := range []string{
+		"DEBUG",
+		"[MILES.TEST]",
+		"stream event",
+		"deltaLen=3",
+		"state=speaking",
+		"[mileslog_test.go:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted log missing %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "time=") || strings.Contains(got, "msg=") {
+		t.Fatalf("custom handler must not use slog TextHandler format: %q", got)
+	}
+}
+
+func TestHandlerFiltersBelowConfiguredLevel(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Debug("hidden")
+	logger.Info("shown")
+
+	got := buf.String()
+	if strings.Contains(got, "hidden") {
+		t.Fatalf("debug log should be filtered at info level: %q", got)
+	}
+	if !strings.Contains(got, "shown") {
+		t.Fatalf("info log should be emitted: %q", got)
+	}
+}
+
+func TestHandlerAddsDateForFileSink(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: true}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Info("file line")
+
+	got := buf.String()
+	if len(got) < len("2006-01-02 15:04:05.000") || got[4] != '-' || got[13] != ':' {
+		t.Fatalf("file sink should include full date timestamp, got %q", got)
+	}
+}
+
+func TestPayloadFlagParser(t *testing.T) {
+	t.Setenv("MILES_LOG_PAYLOADS", "1")
+	if !payloadLoggingEnabledFromEnv() {
+		t.Fatal("MILES_LOG_PAYLOADS=1 should enable payload logging")
+	}
+	t.Setenv("MILES_LOG_PAYLOADS", "0")
+	if payloadLoggingEnabledFromEnv() {
+		t.Fatal("MILES_LOG_PAYLOADS=0 should disable payload logging")
+	}
+}
+
+func TestEnabledHonorsLevel(t *testing.T) {
+	h := newHandler([]sink{{writer: &bytes.Buffer{}, includeDate: false}}, slog.LevelWarn)
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("info should be disabled at warn level")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("error should be enabled at warn level")
+	}
+}

--- a/apps/desktop/CMakeLists.txt
+++ b/apps/desktop/CMakeLists.txt
@@ -24,6 +24,8 @@ set(DESKTOP_SOURCES
     src/chat/ChatStreamEvent.h
     src/chat/ChatTextPacer.cpp
     src/chat/ChatTextPacer.h
+    src/logging/MilesLogHandler.cpp
+    src/logging/MilesLogHandler.h
     src/main.cpp
     src/settings/SecretStore.cpp
     src/settings/SecretStore.h
@@ -196,6 +198,24 @@ if(BUILD_TESTING)
     )
 
     add_test(NAME chat_text_pacer_smoke COMMAND ChatTextPacerSmoke)
+
+    add_executable(LoggingFormatterSmoke
+        tests/logging_formatter_smoke.cpp
+        src/logging/MilesLogHandler.cpp
+        src/logging/MilesLogHandler.h
+    )
+
+    target_include_directories(LoggingFormatterSmoke
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    target_link_libraries(LoggingFormatterSmoke
+        PRIVATE
+            Qt6::Core
+    )
+
+    add_test(NAME logging_formatter_smoke COMMAND LoggingFormatterSmoke)
 
     add_executable(SkinManifestLoaderSmoke
         tests/skin_manifest_loader_smoke.cpp

--- a/apps/desktop/CMakeLists.txt
+++ b/apps/desktop/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2 Test)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2)
 include(CTest)
 
 qt_standard_project_setup(REQUIRES 6.5)
@@ -158,6 +158,8 @@ if(TARGET MilesAgentCore)
 endif()
 
 if(BUILD_TESTING)
+    find_package(Qt6 REQUIRED COMPONENTS Test)
+
     add_executable(ChatStreamEventParserSmoke
         tests/chat_stream_event_parser_smoke.cpp
         src/chat/ChatStreamEvent.cpp

--- a/apps/desktop/CMakeLists.txt
+++ b/apps/desktop/CMakeLists.txt
@@ -280,6 +280,8 @@ if(BUILD_TESTING)
         src/chat/ChatController.h
         src/chat/ChatStreamEvent.cpp
         src/chat/ChatStreamEvent.h
+        src/chat/ChatTextPacer.cpp
+        src/chat/ChatTextPacer.h
         src/settings/SecretStore.cpp
         src/settings/SecretStore.h
         src/settings/SettingsService.cpp

--- a/apps/desktop/CMakeLists.txt
+++ b/apps/desktop/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2 Test)
 include(CTest)
 
 qt_standard_project_setup(REQUIRES 6.5)
@@ -22,6 +22,8 @@ set(DESKTOP_SOURCES
     src/chat/ChatController.h
     src/chat/ChatStreamEvent.cpp
     src/chat/ChatStreamEvent.h
+    src/chat/ChatTextPacer.cpp
+    src/chat/ChatTextPacer.h
     src/main.cpp
     src/settings/SecretStore.cpp
     src/settings/SecretStore.h
@@ -173,6 +175,25 @@ if(BUILD_TESTING)
     )
 
     add_test(NAME chat_stream_event_parser_smoke COMMAND ChatStreamEventParserSmoke)
+
+    add_executable(ChatTextPacerSmoke
+        tests/chat_text_pacer_smoke.cpp
+        src/chat/ChatTextPacer.cpp
+        src/chat/ChatTextPacer.h
+    )
+
+    target_include_directories(ChatTextPacerSmoke
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    target_link_libraries(ChatTextPacerSmoke
+        PRIVATE
+            Qt6::Core
+            Qt6::Test
+    )
+
+    add_test(NAME chat_text_pacer_smoke COMMAND ChatTextPacerSmoke)
 
     add_executable(SkinManifestLoaderSmoke
         tests/skin_manifest_loader_smoke.cpp

--- a/apps/desktop/resources/skins/miles-edgeworth/manifest.json
+++ b/apps/desktop/resources/skins/miles-edgeworth/manifest.json
@@ -55,7 +55,8 @@
       "selection": "first_available",
       "actions": [
         { "action": "thinking", "allowedStates": ["thinking"] },
-        { "action": "idle_stand", "allowedStates": ["idle", "speaking", "error"] }
+        { "action": "crossed", "allowedStates": ["speaking"] },
+        { "action": "idle_stand", "allowedStates": ["idle", "error"] }
       ]
     },
     "objection": {

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -11,12 +11,15 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QLoggingCategory>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QUrl>
 #include <QProcessEnvironment>
 
 namespace {
+Q_LOGGING_CATEGORY(chatLog, "miles.chat")
+
 constexpr auto kHealthUrl = "http://127.0.0.1:39710/health";
 constexpr auto kChatMessagesUrl = "http://127.0.0.1:39710/v1/chat/messages";
 constexpr auto kExpressionRequestedEvent = "miles.pet.expression.requested";
@@ -32,6 +35,19 @@ InterruptHint interruptHintFromValue(const QVariantMap &value)
 
     return InterruptHint::Immediate;
 }
+
+void logProcessOutput(const char *label, const QByteArray &bytes)
+{
+    const QList<QByteArray> lines = bytes.split('\n');
+    for (QByteArray line : lines) {
+        if (line.endsWith('\r')) {
+            line.chop(1);
+        }
+        if (!line.trimmed().isEmpty()) {
+            qCDebug(chatLog).noquote() << label << QString::fromLocal8Bit(line);
+        }
+    }
+}
 } // namespace
 
 ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, QObject *parent)
@@ -41,9 +57,15 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
 {
     connect(&m_sidecarProcess, &QProcess::started, this, [this]() {
         setStatusText(QStringLiteral("连接中"));
+        qCDebug(chatLog) << "sidecar process started"
+                         << "pid=" << m_sidecarProcess.processId()
+                         << "program=" << m_sidecarProcess.program();
         QTimer::singleShot(250, this, &ChatController::checkHealth);
     });
     connect(&m_sidecarProcess, &QProcess::errorOccurred, this, [this]() {
+        qCDebug(chatLog) << "sidecar process error"
+                         << "error=" << m_sidecarProcess.error()
+                         << "message=" << m_sidecarProcess.errorString();
         setSidecarReady(false);
         if (!m_sidecarRestartPending) {
             setStatusText(QStringLiteral("未连接"));
@@ -53,6 +75,9 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
             qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
             this,
             [this](int, QProcess::ExitStatus) {
+                qCDebug(chatLog) << "sidecar process finished"
+                                 << "exitCode=" << m_sidecarProcess.exitCode()
+                                 << "exitStatus=" << m_sidecarProcess.exitStatus();
                 setSidecarReady(false);
                 if (m_sidecarStoppingForRestart) {
                     setStatusText(QStringLiteral("重启中"));
@@ -67,6 +92,12 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
                 m_sidecarRestartAttempts = 0;
                 setStatusText(QStringLiteral("未连接"));
             });
+    connect(&m_sidecarProcess, &QProcess::readyReadStandardError, this, [this]() {
+        logProcessOutput("sidecar stderr", m_sidecarProcess.readAllStandardError());
+    });
+    connect(&m_sidecarProcess, &QProcess::readyReadStandardOutput, this, [this]() {
+        logProcessOutput("sidecar stdout", m_sidecarProcess.readAllStandardOutput());
+    });
 
     m_pacer = new ChatTextPacer(this);
     connect(m_pacer, &ChatTextPacer::chunkReady,
@@ -107,6 +138,8 @@ void ChatController::startSidecar()
 void ChatController::launchSidecarProcess()
 {
     if (m_sidecarProcess.state() != QProcess::NotRunning) {
+        qCDebug(chatLog) << "sidecar already running under this app"
+                         << "pid=" << m_sidecarProcess.processId();
         checkHealth();
         return;
     }
@@ -142,6 +175,12 @@ void ChatController::launchSidecarProcess()
     }
 
     m_sidecarProcess.setProcessEnvironment(env);
+    qCDebug(chatLog) << "launch sidecar"
+                     << "path=" << executablePath
+                     << "baseUrlSet=" << env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL"))
+                     << "apiKeySet=" << env.contains(QStringLiteral("MILES_PROVIDER_API_KEY"))
+                     << "model=" << env.value(QStringLiteral("MILES_PROVIDER_MODEL"))
+                     << "debug=" << env.contains(QStringLiteral("MILES_DEBUG_CHAT"));
     setStatusText(QStringLiteral("启动中"));
     if (m_sidecarRestartPending) {
         ++m_sidecarRestartAttempts;
@@ -191,7 +230,19 @@ void ChatController::checkHealth()
 {
     QNetworkReply *reply = m_network.get(QNetworkRequest(QUrl(QString::fromLatin1(kHealthUrl))));
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-        const bool healthy = reply->error() == QNetworkReply::NoError;
+        const QByteArray body = reply->readAll();
+        const QJsonObject health = QJsonDocument::fromJson(body).object();
+        const qint64 ownedPid = m_sidecarProcess.processId();
+        const int healthPid = health.value(QStringLiteral("pid")).toInt();
+        const bool healthy = reply->error() == QNetworkReply::NoError
+            && ownedPid > 0
+            && healthPid == ownedPid;
+        qCDebug(chatLog) << "sidecar health"
+                         << "healthy=" << healthy
+                         << "pid=" << healthPid
+                         << "ownedPid=" << ownedPid
+                         << "provider=" << health.value(QStringLiteral("provider")).toString()
+                         << "error=" << reply->errorString();
         reply->deleteLater();
         setSidecarReady(healthy);
         if (healthy) {
@@ -248,6 +299,9 @@ void ChatController::sendMessage(const QString &message)
             expressionsArray.append(entry);
         }
         body.insert(QStringLiteral("expressions"), expressionsArray);
+        qCDebug(chatLog) << "send chat request"
+                         << "messageLen=" << trimmed.size()
+                         << "expressions=" << expressionsArray.size();
     }
 
     if (QCoreApplication::instance() == nullptr) {
@@ -441,11 +495,11 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
         const QString state = event.value.value(QStringLiteral("state")).toString();
         const QString expression = event.value.value(QStringLiteral("expression")).toString();
-        qInfo().noquote() << "chat expression requested"
-                          << "phase=" << static_cast<int>(m_phase)
-                          << "state=" << state
-                          << "expression=" << expression
-                          << "interruptHint=" << event.value.value(QStringLiteral("interruptHint")).toString();
+        qCDebug(chatLog).noquote() << "chat expression requested"
+                                    << "phase=" << static_cast<int>(m_phase)
+                                    << "state=" << state
+                                    << "expression=" << expression
+                                    << "interruptHint=" << event.value.value(QStringLiteral("interruptHint")).toString();
 
         if (m_phase == ChatPhase::BUFFERING_FOR_START || m_phase == ChatPhase::GATED) {
             m_pendingState = state;
@@ -652,7 +706,16 @@ QString ChatController::sidecarExecutablePath() const
 void ChatController::handleStreamBytes(const QByteArray &bytes)
 {
     const QList<ChatStreamEvent> events = m_parser.ingest(bytes);
+    qCDebug(chatLog) << "stream bytes received"
+                     << "bytes=" << bytes.size()
+                     << "events=" << events.size();
     for (const ChatStreamEvent &event : events) {
+        qCDebug(chatLog) << "stream event"
+                         << "type=" << event.type
+                         << "name=" << event.name
+                         << "state=" << event.value.value(QStringLiteral("state")).toString()
+                         << "expression=" << event.value.value(QStringLiteral("expression")).toString()
+                         << "deltaLen=" << event.delta.size();
         applyStreamEvent(event);
     }
 }

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -36,18 +36,6 @@ InterruptHint interruptHintFromValue(const QVariantMap &value)
     return InterruptHint::Immediate;
 }
 
-void logProcessOutput(const char *label, const QByteArray &bytes)
-{
-    const QList<QByteArray> lines = bytes.split('\n');
-    for (QByteArray line : lines) {
-        if (line.endsWith('\r')) {
-            line.chop(1);
-        }
-        if (!line.trimmed().isEmpty()) {
-            qCDebug(chatLog).noquote() << label << QString::fromLocal8Bit(line);
-        }
-    }
-}
 } // namespace
 
 ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, QObject *parent)
@@ -55,6 +43,8 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
     , m_runtime(runtime)
     , m_settings(settings)
 {
+    m_sidecarProcess.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+
     connect(&m_sidecarProcess, &QProcess::started, this, [this]() {
         setStatusText(QStringLiteral("连接中"));
         qCDebug(chatLog) << "sidecar process started"
@@ -92,12 +82,6 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
                 m_sidecarRestartAttempts = 0;
                 setStatusText(QStringLiteral("未连接"));
             });
-    connect(&m_sidecarProcess, &QProcess::readyReadStandardError, this, [this]() {
-        logProcessOutput("sidecar stderr", m_sidecarProcess.readAllStandardError());
-    });
-    connect(&m_sidecarProcess, &QProcess::readyReadStandardOutput, this, [this]() {
-        logProcessOutput("sidecar stdout", m_sidecarProcess.readAllStandardOutput());
-    });
 
     m_pacer = new ChatTextPacer(this);
     connect(m_pacer, &ChatTextPacer::chunkReady,
@@ -154,6 +138,18 @@ void ChatController::launchSidecarProcess()
     }
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QProcessEnvironment systemEnv = QProcessEnvironment::systemEnvironment();
+    const QStringList logEnvNames{
+        QStringLiteral("MILES_LOG_FILE"),
+        QStringLiteral("MILES_LOG_LEVEL"),
+        QStringLiteral("MILES_LOG_PAYLOADS"),
+    };
+    for (const QString &name : logEnvNames) {
+        if (systemEnv.contains(name)) {
+            env.insert(name, systemEnv.value(name));
+        }
+    }
+
     if (m_settings != nullptr) {
         const QString baseUrl = m_settings->baseUrl();
         if (!baseUrl.isEmpty()) {
@@ -175,12 +171,14 @@ void ChatController::launchSidecarProcess()
     }
 
     m_sidecarProcess.setProcessEnvironment(env);
-    qCDebug(chatLog) << "launch sidecar"
-                     << "path=" << executablePath
-                     << "baseUrlSet=" << env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL"))
-                     << "apiKeySet=" << env.contains(QStringLiteral("MILES_PROVIDER_API_KEY"))
-                     << "model=" << env.value(QStringLiteral("MILES_PROVIDER_MODEL"))
-                     << "debug=" << env.contains(QStringLiteral("MILES_DEBUG_CHAT"));
+    qCDebug(chatLog).noquote() << "launch sidecar"
+                               << QStringLiteral("path=%1").arg(executablePath)
+                               << QStringLiteral("baseUrlSet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL")))
+                               << QStringLiteral("apiKeySet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_API_KEY")))
+                               << QStringLiteral("model=%1").arg(env.value(QStringLiteral("MILES_PROVIDER_MODEL")))
+                               << QStringLiteral("logLevel=%1").arg(env.value(QStringLiteral("MILES_LOG_LEVEL"), QStringLiteral("info")))
+                               << QStringLiteral("logFileSet=%1").arg(env.contains(QStringLiteral("MILES_LOG_FILE")))
+                               << QStringLiteral("payloads=%1").arg(env.value(QStringLiteral("MILES_LOG_PAYLOADS")) == QStringLiteral("1"));
     setStatusText(QStringLiteral("启动中"));
     if (m_sidecarRestartPending) {
         ++m_sidecarRestartAttempts;

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -287,12 +287,22 @@ void ChatController::sendMessage(const QString &message)
 
 void ChatController::cancelCurrentReply()
 {
-    if (!m_sending && m_currentReply.isNull()) {
+    const bool activePhase = m_phase != ChatPhase::IDLE;
+    if (!m_sending && m_currentReply.isNull() && !activePhase) {
         return;
     }
 
     m_cancelled = true;
-    m_holdBuffer.clear();
+    m_gateTimeout.stop();
+    m_pendingExpression.clear();
+    m_pendingState.clear();
+    if (!m_holdBuffer.isEmpty()
+            && (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size())) {
+        appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
+        m_assistantMessageIndex = m_messages.size() - 1;
+    }
+    drainHoldBufferToPacer();
+    transitionTo(ChatPhase::IDLE);
     if (m_currentReply) {
         QNetworkReply *reply = m_currentReply;
         m_currentReply.clear();
@@ -307,10 +317,11 @@ void ChatController::cancelCurrentReply()
         emit messagesChanged();
     }
 
-    m_assistantMessageIndex = -1;
     setSending(false);
     setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
-    requestPetExpression(QStringLiteral("idle"), QStringLiteral("neutral"));
+    if (m_runtime != nullptr) {
+        m_runtime->returnToIdle();
+    }
 }
 
 void ChatController::applyStreamEvent(const ChatStreamEvent &event)
@@ -564,11 +575,14 @@ void ChatController::drainHoldBufferToPacer()
 
 void ChatController::appendChunkToCurrentMessage(const QString &chunk)
 {
-    if (m_cancelled || chunk.isEmpty()) {
+    if (chunk.isEmpty()) {
         return;
     }
 
     if (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size()) {
+        if (m_cancelled) {
+            return;
+        }
         appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
         m_assistantMessageIndex = m_messages.size() - 1;
     }
@@ -672,10 +686,24 @@ void ChatController::finishCurrentReply()
 void ChatController::failCurrentReply(const QString &message)
 {
     const QString text = message.trimmed().isEmpty() ? QStringLiteral("请求失败") : message.trimmed();
+    const bool hasBufferedText = !m_holdBuffer.isEmpty();
+
+    m_gateTimeout.stop();
+    m_pendingExpression.clear();
+    m_pendingState.clear();
+    if (hasBufferedText
+            && (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size())) {
+        appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
+        m_assistantMessageIndex = m_messages.size() - 1;
+    }
+    drainHoldBufferToPacer();
+    transitionTo(ChatPhase::IDLE);
 
     if (m_assistantMessageIndex >= 0 && m_assistantMessageIndex < m_messages.size()) {
         QVariantMap assistantMessage = m_messages.at(m_assistantMessageIndex).toMap();
-        assistantMessage.insert(QStringLiteral("text"), text);
+        if (assistantMessage.value(QStringLiteral("text")).toString().isEmpty() && !hasBufferedText) {
+            assistantMessage.insert(QStringLiteral("text"), text);
+        }
         assistantMessage.insert(QStringLiteral("pending"), false);
         assistantMessage.insert(QStringLiteral("error"), true);
         m_messages[m_assistantMessageIndex] = assistantMessage;

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -712,7 +712,6 @@ void ChatController::failCurrentReply(const QString &message)
         appendMessage(messageObject(QStringLiteral("assistant"), text, false, true));
     }
 
-    m_assistantMessageIndex = -1;
     m_currentReply.clear();
     setSending(false);
     setStatusText(QStringLiteral("错误"));

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -357,6 +357,13 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
                 m_holdBuffer.append(event.delta);
                 flushHoldBuffer();
             }
+        } else if (m_phase == ChatPhase::WAITING_FOR_ANIMATION_END) {
+            if (m_pacer != nullptr) {
+                m_pacer->append(event.delta);
+            } else {
+                m_holdBuffer.append(event.delta);
+                flushHoldBuffer();
+            }
         } else {
             m_holdBuffer.append(event.delta);
         }
@@ -374,7 +381,33 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     }
 
     if (event.type == QStringLiteral("RUN_FINISHED")) {
-        finishCurrentReply();
+        if (m_assistantMessageIndex >= 0 && m_assistantMessageIndex < m_messages.size()) {
+            QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+            message.insert(QStringLiteral("pending"), false);
+            m_messages[m_assistantMessageIndex] = message;
+            emit messagesChanged();
+        }
+
+        m_currentReply.clear();
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+        setSending(false);
+        setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
+        drainHoldBufferToPacer();
+
+        if (m_runtime == nullptr) {
+            transitionTo(ChatPhase::IDLE);
+            m_assistantMessageIndex = -1;
+            return;
+        }
+
+        transitionTo(ChatPhase::WAITING_FOR_ANIMATION_END);
+        QPointer<ChatController> self(this);
+        m_runtime->requestBoundaryAndNotify([self]() {
+            if (self != nullptr) {
+                self->handleBoundaryReached();
+            }
+        });
         return;
     }
 
@@ -499,6 +532,7 @@ void ChatController::handleBoundaryReached()
         if (m_runtime != nullptr) {
             m_runtime->returnToIdle();
         }
+        m_assistantMessageIndex = -1;
         transitionTo(ChatPhase::IDLE);
     }
 }
@@ -541,7 +575,7 @@ void ChatController::appendChunkToCurrentMessage(const QString &chunk)
 
     QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
     message.insert(QStringLiteral("text"), message.value(QStringLiteral("text")).toString() + chunk);
-    message.insert(QStringLiteral("pending"), true);
+    message.insert(QStringLiteral("pending"), m_sending);
     m_messages[m_assistantMessageIndex] = message;
     emit messagesChanged();
 }

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -1,5 +1,6 @@
 #include "chat/ChatController.h"
 
+#include "chat/ChatTextPacer.h"
 #include "pet/PetRuntime.h"
 #include "settings/SettingsService.h"
 
@@ -65,6 +66,17 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
                 m_sidecarRestartAttempts = 0;
                 setStatusText(QStringLiteral("未连接"));
             });
+
+    m_pacer = new ChatTextPacer(this);
+    connect(m_pacer, &ChatTextPacer::chunkReady,
+            this, &ChatController::appendChunkToCurrentMessage);
+    if (m_settings != nullptr) {
+        m_pacer->setMsPerChar(m_settings->msPerChar());
+    }
+
+    m_gateTimeout.setSingleShot(true);
+    connect(&m_gateTimeout, &QTimer::timeout,
+            this, &ChatController::handleGateTimeout);
 }
 
 ChatController::~ChatController()
@@ -169,6 +181,9 @@ void ChatController::restartSidecar()
 void ChatController::handleSettingsSaved()
 {
     restartSidecar();
+    if (m_settings != nullptr && m_pacer != nullptr) {
+        m_pacer->setMsPerChar(m_settings->msPerChar());
+    }
 }
 
 void ChatController::checkHealth()
@@ -307,6 +322,20 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     if (event.type == QStringLiteral("RUN_STARTED")) {
         setSending(true);
         setStatusText(QStringLiteral("正在回复"));
+        m_holdBuffer.clear();
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+        transitionTo(ChatPhase::BUFFERING_FOR_START);
+        if (m_runtime != nullptr) {
+            QPointer<ChatController> self(this);
+            m_runtime->requestCleanFinishAndNotify([self]() {
+                if (self != nullptr) {
+                    self->handleCleanFinishReady();
+                }
+            });
+        } else {
+            handleCleanFinishReady();
+        }
         return;
     }
 
@@ -321,7 +350,16 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     }
 
     if (event.type == QStringLiteral("TEXT_MESSAGE_CONTENT")) {
-        appendAssistantDelta(event.delta);
+        if (m_phase == ChatPhase::STREAMING) {
+            if (m_pacer != nullptr) {
+                m_pacer->append(event.delta);
+            } else {
+                m_holdBuffer.append(event.delta);
+                flushHoldBuffer();
+            }
+        } else {
+            m_holdBuffer.append(event.delta);
+        }
         return;
     }
 
@@ -346,9 +384,32 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     }
 
     if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
-        requestPetExpression(event.value.value(QStringLiteral("state")).toString(),
-                             event.value.value(QStringLiteral("expression")).toString(),
-                             interruptHintFromValue(event.value));
+        const QString state = event.value.value(QStringLiteral("state")).toString();
+        const QString expression = event.value.value(QStringLiteral("expression")).toString();
+
+        if (m_phase == ChatPhase::BUFFERING_FOR_START || m_phase == ChatPhase::GATED) {
+            m_pendingState = state;
+            m_pendingExpression = expression;
+            return;
+        }
+
+        if (m_phase == ChatPhase::STREAMING) {
+            m_pendingState = state;
+            m_pendingExpression = expression;
+            transitionTo(ChatPhase::GATED);
+            m_gateTimeout.start(kGateTimeoutMs);
+            if (m_runtime != nullptr) {
+                QPointer<ChatController> self(this);
+                m_runtime->requestBoundaryAndNotify([self]() {
+                    if (self != nullptr) {
+                        self->handleBoundaryReached();
+                    }
+                });
+            }
+            return;
+        }
+
+        requestPetExpression(state, expression, interruptHintFromValue(event.value));
     }
 }
 
@@ -394,6 +455,94 @@ void ChatController::flushHoldBuffer()
     message.insert(QStringLiteral("pending"), true);
     m_messages[m_assistantMessageIndex] = message;
     m_holdBuffer.clear();
+    emit messagesChanged();
+}
+
+void ChatController::transitionTo(ChatPhase next)
+{
+    if (m_phase == next) {
+        return;
+    }
+    m_phase = next;
+}
+
+void ChatController::handleCleanFinishReady()
+{
+    if (m_phase != ChatPhase::BUFFERING_FOR_START) {
+        return;
+    }
+
+    if (!m_pendingExpression.isEmpty()) {
+        requestPetExpression(m_pendingState, m_pendingExpression);
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+    }
+    transitionTo(ChatPhase::STREAMING);
+    drainHoldBufferToPacer();
+}
+
+void ChatController::handleBoundaryReached()
+{
+    m_gateTimeout.stop();
+    if (m_phase == ChatPhase::GATED) {
+        if (!m_pendingExpression.isEmpty()) {
+            requestPetExpression(m_pendingState, m_pendingExpression);
+            m_pendingExpression.clear();
+            m_pendingState.clear();
+        }
+        transitionTo(ChatPhase::STREAMING);
+        drainHoldBufferToPacer();
+        return;
+    }
+
+    if (m_phase == ChatPhase::WAITING_FOR_ANIMATION_END) {
+        if (m_runtime != nullptr) {
+            m_runtime->returnToIdle();
+        }
+        transitionTo(ChatPhase::IDLE);
+    }
+}
+
+void ChatController::handleGateTimeout()
+{
+    if (m_phase != ChatPhase::GATED) {
+        return;
+    }
+
+    if (!m_pendingExpression.isEmpty()) {
+        requestPetExpression(m_pendingState, m_pendingExpression);
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+    }
+    transitionTo(ChatPhase::STREAMING);
+    drainHoldBufferToPacer();
+}
+
+void ChatController::drainHoldBufferToPacer()
+{
+    if (m_holdBuffer.isEmpty() || m_pacer == nullptr) {
+        return;
+    }
+
+    m_pacer->append(m_holdBuffer);
+    m_holdBuffer.clear();
+}
+
+void ChatController::appendChunkToCurrentMessage(const QString &chunk)
+{
+    if (m_cancelled || chunk.isEmpty()) {
+        return;
+    }
+
+    if (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size()) {
+        appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
+        m_assistantMessageIndex = m_messages.size() - 1;
+    }
+
+    QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+    message.insert(QStringLiteral("text"), message.value(QStringLiteral("text")).toString() + chunk);
+    message.insert(QStringLiteral("pending"), true);
+    m_messages[m_assistantMessageIndex] = message;
     emit messagesChanged();
 }
 

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -208,6 +208,7 @@ void ChatController::sendMessage(const QString &message)
         return;
     }
 
+    ++m_currentStreamId;
     m_cancelled = false;
     appendMessage(messageObject(QStringLiteral("user"), trimmed, false, false));
     appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -365,15 +365,13 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
             if (m_pacer != nullptr) {
                 m_pacer->append(event.delta);
             } else {
-                m_holdBuffer.append(event.delta);
-                flushHoldBuffer();
+                appendChunkToCurrentMessage(event.delta);
             }
         } else if (m_phase == ChatPhase::WAITING_FOR_ANIMATION_END) {
             if (m_pacer != nullptr) {
                 m_pacer->append(event.delta);
             } else {
-                m_holdBuffer.append(event.delta);
-                flushHoldBuffer();
+                appendChunkToCurrentMessage(event.delta);
             }
         } else {
             m_holdBuffer.append(event.delta);
@@ -473,35 +471,6 @@ void ChatController::appendMessage(const QVariantMap &message)
     emit messagesChanged();
 }
 
-void ChatController::appendAssistantDelta(const QString &delta)
-{
-    if (m_cancelled) {
-        return;
-    }
-
-    m_holdBuffer.append(delta);
-    flushHoldBuffer();
-}
-
-void ChatController::flushHoldBuffer()
-{
-    if (m_cancelled || m_holdBuffer.isEmpty()) {
-        return;
-    }
-
-    if (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size()) {
-        appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
-        m_assistantMessageIndex = m_messages.size() - 1;
-    }
-
-    QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
-    message.insert(QStringLiteral("text"), message.value(QStringLiteral("text")).toString() + m_holdBuffer);
-    message.insert(QStringLiteral("pending"), true);
-    m_messages[m_assistantMessageIndex] = message;
-    m_holdBuffer.clear();
-    emit messagesChanged();
-}
-
 void ChatController::transitionTo(ChatPhase next)
 {
     if (m_phase == next) {
@@ -565,11 +534,15 @@ void ChatController::handleGateTimeout()
 
 void ChatController::drainHoldBufferToPacer()
 {
-    if (m_holdBuffer.isEmpty() || m_pacer == nullptr) {
+    if (m_holdBuffer.isEmpty()) {
         return;
     }
 
-    m_pacer->append(m_holdBuffer);
+    if (m_pacer != nullptr) {
+        m_pacer->append(m_holdBuffer);
+    } else {
+        appendChunkToCurrentMessage(m_holdBuffer);
+    }
     m_holdBuffer.clear();
 }
 

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -5,6 +5,7 @@
 #include "settings/SettingsService.h"
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QDir>
 #include <QFileInfo>
 #include <QJsonArray>
@@ -440,6 +441,11 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
         const QString state = event.value.value(QStringLiteral("state")).toString();
         const QString expression = event.value.value(QStringLiteral("expression")).toString();
+        qInfo().noquote() << "chat expression requested"
+                          << "phase=" << static_cast<int>(m_phase)
+                          << "state=" << state
+                          << "expression=" << expression
+                          << "interruptHint=" << event.value.value(QStringLiteral("interruptHint")).toString();
 
         if (m_phase == ChatPhase::BUFFERING_FOR_START || m_phase == ChatPhase::GATED) {
             m_pendingState = state;

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -47,15 +47,15 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
 
     connect(&m_sidecarProcess, &QProcess::started, this, [this]() {
         setStatusText(QStringLiteral("连接中"));
-        qCDebug(chatLog) << "sidecar process started"
-                         << "pid=" << m_sidecarProcess.processId()
-                         << "program=" << m_sidecarProcess.program();
+        qCDebug(chatLog).noquote() << "sidecar process started"
+                                    << QStringLiteral("pid=%1").arg(m_sidecarProcess.processId())
+                                    << QStringLiteral("program=%1").arg(m_sidecarProcess.program());
         QTimer::singleShot(250, this, &ChatController::checkHealth);
     });
     connect(&m_sidecarProcess, &QProcess::errorOccurred, this, [this]() {
-        qCDebug(chatLog) << "sidecar process error"
-                         << "error=" << m_sidecarProcess.error()
-                         << "message=" << m_sidecarProcess.errorString();
+        qCDebug(chatLog).noquote() << "sidecar process error"
+                                    << QStringLiteral("error=%1").arg(m_sidecarProcess.error())
+                                    << QStringLiteral("message=%1").arg(m_sidecarProcess.errorString());
         setSidecarReady(false);
         if (!m_sidecarRestartPending) {
             setStatusText(QStringLiteral("未连接"));
@@ -65,9 +65,9 @@ ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, Q
             qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
             this,
             [this](int, QProcess::ExitStatus) {
-                qCDebug(chatLog) << "sidecar process finished"
-                                 << "exitCode=" << m_sidecarProcess.exitCode()
-                                 << "exitStatus=" << m_sidecarProcess.exitStatus();
+                qCDebug(chatLog).noquote() << "sidecar process finished"
+                                            << QStringLiteral("exitCode=%1").arg(m_sidecarProcess.exitCode())
+                                            << QStringLiteral("exitStatus=%1").arg(m_sidecarProcess.exitStatus());
                 setSidecarReady(false);
                 if (m_sidecarStoppingForRestart) {
                     setStatusText(QStringLiteral("重启中"));
@@ -122,8 +122,8 @@ void ChatController::startSidecar()
 void ChatController::launchSidecarProcess()
 {
     if (m_sidecarProcess.state() != QProcess::NotRunning) {
-        qCDebug(chatLog) << "sidecar already running under this app"
-                         << "pid=" << m_sidecarProcess.processId();
+        qCDebug(chatLog).noquote() << "sidecar already running under this app"
+                                    << QStringLiteral("pid=%1").arg(m_sidecarProcess.processId());
         checkHealth();
         return;
     }
@@ -235,12 +235,12 @@ void ChatController::checkHealth()
         const bool healthy = reply->error() == QNetworkReply::NoError
             && ownedPid > 0
             && healthPid == ownedPid;
-        qCDebug(chatLog) << "sidecar health"
-                         << "healthy=" << healthy
-                         << "pid=" << healthPid
-                         << "ownedPid=" << ownedPid
-                         << "provider=" << health.value(QStringLiteral("provider")).toString()
-                         << "error=" << reply->errorString();
+        qCDebug(chatLog).noquote() << "sidecar health"
+                                    << QStringLiteral("healthy=%1").arg(healthy)
+                                    << QStringLiteral("pid=%1").arg(healthPid)
+                                    << QStringLiteral("ownedPid=%1").arg(ownedPid)
+                                    << QStringLiteral("provider=%1").arg(health.value(QStringLiteral("provider")).toString())
+                                    << QStringLiteral("error=%1").arg(reply->errorString());
         reply->deleteLater();
         setSidecarReady(healthy);
         if (healthy) {
@@ -297,9 +297,9 @@ void ChatController::sendMessage(const QString &message)
             expressionsArray.append(entry);
         }
         body.insert(QStringLiteral("expressions"), expressionsArray);
-        qCDebug(chatLog) << "send chat request"
-                         << "messageLen=" << trimmed.size()
-                         << "expressions=" << expressionsArray.size();
+        qCDebug(chatLog).noquote() << "send chat request"
+                                    << QStringLiteral("messageLen=%1").arg(trimmed.size())
+                                    << QStringLiteral("expressions=%1").arg(expressionsArray.size());
     }
 
     if (QCoreApplication::instance() == nullptr) {
@@ -504,10 +504,10 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
         const QString state = event.value.value(QStringLiteral("state")).toString();
         const QString expression = event.value.value(QStringLiteral("expression")).toString();
         qCDebug(chatLog).noquote() << "chat expression requested"
-                                    << "phase=" << static_cast<int>(m_phase)
-                                    << "state=" << state
-                                    << "expression=" << expression
-                                    << "interruptHint=" << event.value.value(QStringLiteral("interruptHint")).toString();
+                                    << QStringLiteral("phase=%1").arg(static_cast<int>(m_phase))
+                                    << QStringLiteral("state=%1").arg(state)
+                                    << QStringLiteral("expression=%1").arg(expression)
+                                    << QStringLiteral("interruptHint=%1").arg(event.value.value(QStringLiteral("interruptHint")).toString());
 
         if (m_phase == ChatPhase::BUFFERING_FOR_START || m_phase == ChatPhase::GATED) {
             m_pendingState = state;
@@ -731,16 +731,16 @@ QString ChatController::sidecarExecutablePath() const
 void ChatController::handleStreamBytes(const QByteArray &bytes)
 {
     const QList<ChatStreamEvent> events = m_parser.ingest(bytes);
-    qCDebug(chatLog) << "stream bytes received"
-                     << "bytes=" << bytes.size()
-                     << "events=" << events.size();
+    qCDebug(chatLog).noquote() << "stream bytes received"
+                                << QStringLiteral("bytes=%1").arg(bytes.size())
+                                << QStringLiteral("events=%1").arg(events.size());
     for (const ChatStreamEvent &event : events) {
-        qCDebug(chatLog) << "stream event"
-                         << "type=" << event.type
-                         << "name=" << event.name
-                         << "state=" << event.value.value(QStringLiteral("state")).toString()
-                         << "expression=" << event.value.value(QStringLiteral("expression")).toString()
-                         << "deltaLen=" << event.delta.size();
+        qCDebug(chatLog).noquote() << "stream event"
+                                    << QStringLiteral("type=%1").arg(event.type)
+                                    << QStringLiteral("name=%1").arg(event.name)
+                                    << QStringLiteral("state=%1").arg(event.value.value(QStringLiteral("state")).toString())
+                                    << QStringLiteral("expression=%1").arg(event.value.value(QStringLiteral("expression")).toString())
+                                    << QStringLiteral("deltaLen=%1").arg(event.delta.size());
         applyStreamEvent(event);
     }
 }

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -209,6 +209,9 @@ void ChatController::sendMessage(const QString &message)
     }
 
     ++m_currentStreamId;
+    if (m_pacer != nullptr) {
+        m_pacer->discardBeforeStream(m_currentStreamId);
+    }
     m_cancelled = false;
     appendMessage(messageObject(QStringLiteral("user"), trimmed, false, false));
     appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
@@ -333,6 +336,9 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
 
     if (event.type == QStringLiteral("RUN_STARTED")) {
         ++m_currentStreamId;
+        if (m_pacer != nullptr) {
+            m_pacer->discardBeforeStream(m_currentStreamId);
+        }
         const bool wasSending = m_sending;
         if (!wasSending) {
             m_assistantMessageIndex = -1;

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -331,6 +331,11 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     }
 
     if (event.type == QStringLiteral("RUN_STARTED")) {
+        ++m_currentStreamId;
+        const bool wasSending = m_sending;
+        if (!wasSending) {
+            m_assistantMessageIndex = -1;
+        }
         setSending(true);
         setStatusText(QStringLiteral("正在回复"));
         m_holdBuffer.clear();
@@ -363,15 +368,15 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
     if (event.type == QStringLiteral("TEXT_MESSAGE_CONTENT")) {
         if (m_phase == ChatPhase::STREAMING) {
             if (m_pacer != nullptr) {
-                m_pacer->append(event.delta);
+                m_pacer->append(event.delta, m_currentStreamId);
             } else {
-                appendChunkToCurrentMessage(event.delta);
+                appendChunkToCurrentMessage(event.delta, m_currentStreamId);
             }
         } else if (m_phase == ChatPhase::WAITING_FOR_ANIMATION_END) {
             if (m_pacer != nullptr) {
-                m_pacer->append(event.delta);
+                m_pacer->append(event.delta, m_currentStreamId);
             } else {
-                appendChunkToCurrentMessage(event.delta);
+                appendChunkToCurrentMessage(event.delta, m_currentStreamId);
             }
         } else {
             m_holdBuffer.append(event.delta);
@@ -512,7 +517,6 @@ void ChatController::handleBoundaryReached()
         if (m_runtime != nullptr) {
             m_runtime->returnToIdle();
         }
-        m_assistantMessageIndex = -1;
         transitionTo(ChatPhase::IDLE);
     }
 }
@@ -539,16 +543,16 @@ void ChatController::drainHoldBufferToPacer()
     }
 
     if (m_pacer != nullptr) {
-        m_pacer->append(m_holdBuffer);
+        m_pacer->append(m_holdBuffer, m_currentStreamId);
     } else {
-        appendChunkToCurrentMessage(m_holdBuffer);
+        appendChunkToCurrentMessage(m_holdBuffer, m_currentStreamId);
     }
     m_holdBuffer.clear();
 }
 
-void ChatController::appendChunkToCurrentMessage(const QString &chunk)
+void ChatController::appendChunkToCurrentMessage(const QString &chunk, quint64 streamId)
 {
-    if (chunk.isEmpty()) {
+    if (chunk.isEmpty() || streamId != m_currentStreamId) {
         return;
     }
 

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -36,6 +36,11 @@ InterruptHint interruptHintFromValue(const QVariantMap &value)
     return InterruptHint::Immediate;
 }
 
+QString logBool(bool value)
+{
+    return value ? QStringLiteral("true") : QStringLiteral("false");
+}
+
 } // namespace
 
 ChatController::ChatController(PetRuntime *runtime, SettingsService *settings, QObject *parent)
@@ -173,12 +178,12 @@ void ChatController::launchSidecarProcess()
     m_sidecarProcess.setProcessEnvironment(env);
     qCDebug(chatLog).noquote() << "launch sidecar"
                                << QStringLiteral("path=%1").arg(executablePath)
-                               << QStringLiteral("baseUrlSet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL")))
-                               << QStringLiteral("apiKeySet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_API_KEY")))
+                               << QStringLiteral("baseUrlSet=%1").arg(logBool(env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL"))))
+                               << QStringLiteral("apiKeySet=%1").arg(logBool(env.contains(QStringLiteral("MILES_PROVIDER_API_KEY"))))
                                << QStringLiteral("model=%1").arg(env.value(QStringLiteral("MILES_PROVIDER_MODEL")))
                                << QStringLiteral("logLevel=%1").arg(env.value(QStringLiteral("MILES_LOG_LEVEL"), QStringLiteral("info")))
-                               << QStringLiteral("logFileSet=%1").arg(env.contains(QStringLiteral("MILES_LOG_FILE")))
-                               << QStringLiteral("payloads=%1").arg(env.value(QStringLiteral("MILES_LOG_PAYLOADS")) == QStringLiteral("1"));
+                               << QStringLiteral("logFileSet=%1").arg(logBool(env.contains(QStringLiteral("MILES_LOG_FILE"))))
+                               << QStringLiteral("payloads=%1").arg(logBool(env.value(QStringLiteral("MILES_LOG_PAYLOADS")) == QStringLiteral("1")));
     setStatusText(QStringLiteral("启动中"));
     if (m_sidecarRestartPending) {
         ++m_sidecarRestartAttempts;
@@ -236,7 +241,7 @@ void ChatController::checkHealth()
             && ownedPid > 0
             && healthPid == ownedPid;
         qCDebug(chatLog).noquote() << "sidecar health"
-                                    << QStringLiteral("healthy=%1").arg(healthy)
+                                    << QStringLiteral("healthy=%1").arg(logBool(healthy))
                                     << QStringLiteral("pid=%1").arg(healthPid)
                                     << QStringLiteral("ownedPid=%1").arg(ownedPid)
                                     << QStringLiteral("provider=%1").arg(health.value(QStringLiteral("provider")).toString())

--- a/apps/desktop/src/chat/ChatController.cpp
+++ b/apps/desktop/src/chat/ChatController.cpp
@@ -18,7 +18,7 @@
 #include <QProcessEnvironment>
 
 namespace {
-Q_LOGGING_CATEGORY(chatLog, "miles.chat")
+Q_LOGGING_CATEGORY(chatLog, "miles.chat", QtInfoMsg)
 
 constexpr auto kHealthUrl = "http://127.0.0.1:39710/health";
 constexpr auto kChatMessagesUrl = "http://127.0.0.1:39710/v1/chat/messages";
@@ -355,6 +355,7 @@ void ChatController::cancelCurrentReply()
     m_gateTimeout.stop();
     m_pendingExpression.clear();
     m_pendingState.clear();
+    m_finishPendingAfterStart = false;
     if (!m_holdBuffer.isEmpty()
             && (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size())) {
         appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
@@ -403,6 +404,7 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
         m_holdBuffer.clear();
         m_pendingExpression.clear();
         m_pendingState.clear();
+        m_finishPendingAfterStart = false;
         transitionTo(ChatPhase::BUFFERING_FOR_START);
         if (m_runtime != nullptr) {
             QPointer<ChatController> self(this);
@@ -465,8 +467,16 @@ void ChatController::applyStreamEvent(const ChatStreamEvent &event)
         }
 
         m_currentReply.clear();
+        if (m_phase == ChatPhase::BUFFERING_FOR_START) {
+            m_finishPendingAfterStart = true;
+            setSending(false);
+            setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
+            return;
+        }
+
         m_pendingExpression.clear();
         m_pendingState.clear();
+        m_finishPendingAfterStart = false;
         setSending(false);
         setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
         drainHoldBufferToPacer();
@@ -564,6 +574,23 @@ void ChatController::handleCleanFinishReady()
     }
     transitionTo(ChatPhase::STREAMING);
     drainHoldBufferToPacer();
+
+    if (m_finishPendingAfterStart) {
+        m_finishPendingAfterStart = false;
+        if (m_runtime == nullptr) {
+            transitionTo(ChatPhase::IDLE);
+            m_assistantMessageIndex = -1;
+            return;
+        }
+
+        transitionTo(ChatPhase::WAITING_FOR_ANIMATION_END);
+        QPointer<ChatController> self(this);
+        m_runtime->requestBoundaryAndNotify([self]() {
+            if (self != nullptr) {
+                self->handleBoundaryReached();
+            }
+        });
+    }
 }
 
 void ChatController::handleBoundaryReached()
@@ -732,6 +759,7 @@ void ChatController::finishCurrentReply()
     m_assistantMessageIndex = -1;
     m_holdBuffer.clear();
     m_currentReply.clear();
+    m_finishPendingAfterStart = false;
     setSending(false);
     setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
 }
@@ -744,6 +772,7 @@ void ChatController::failCurrentReply(const QString &message)
     m_gateTimeout.stop();
     m_pendingExpression.clear();
     m_pendingState.clear();
+    m_finishPendingAfterStart = false;
     if (hasBufferedText
             && (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size())) {
         appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -73,7 +73,7 @@ private:
     void handleBoundaryReached();
     void handleGateTimeout();
     void drainHoldBufferToPacer();
-    void appendChunkToCurrentMessage(const QString &chunk);
+    void appendChunkToCurrentMessage(const QString &chunk, quint64 streamId);
     void setSidecarReady(bool ready);
     void setSending(bool sending);
     void setStatusText(const QString &statusText);
@@ -116,6 +116,7 @@ private:
     bool m_cancelled = false;
     QString m_statusText = QStringLiteral("未连接");
     int m_assistantMessageIndex = -1;
+    quint64 m_currentStreamId = 1;
 };
 
 struct ChatControllerForeign

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -111,6 +111,7 @@ private:
     bool m_sidecarRestartPending = false;
     bool m_sidecarStoppingForRestart = false;
     int m_sidecarRestartAttempts = 0;
+    bool m_finishPendingAfterStart = false;
     // 用户取消后，剩余 SSE chunks 必须被丢弃，否则会拼到新建的 assistant 消息里产生"幽灵回复"。
     // 每次 sendMessage 复位 false。
     bool m_cancelled = false;

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -14,6 +14,9 @@
 #include <QVariantList>
 #include <QtQml/qqmlregistration.h>
 
+#include <functional>
+
+class ChatTextPacer;
 class QNetworkReply;
 class PetRuntime;
 class SettingsService;
@@ -27,6 +30,14 @@ class ChatController : public QObject
     Q_PROPERTY(QVariantList messages READ messages NOTIFY messagesChanged)
 
 public:
+    enum class ChatPhase {
+        IDLE,
+        BUFFERING_FOR_START,
+        STREAMING,
+        GATED,
+        WAITING_FOR_ANIMATION_END,
+    };
+
     explicit ChatController(PetRuntime *runtime, SettingsService *settings, QObject *parent = nullptr);
     ~ChatController() override;
 
@@ -59,6 +70,12 @@ private:
     void appendMessage(const QVariantMap &message);
     void appendAssistantDelta(const QString &delta);
     void flushHoldBuffer();
+    void transitionTo(ChatPhase next);
+    void handleCleanFinishReady();
+    void handleBoundaryReached();
+    void handleGateTimeout();
+    void drainHoldBufferToPacer();
+    void appendChunkToCurrentMessage(const QString &chunk);
     void setSidecarReady(bool ready);
     void setSending(bool sending);
     void setStatusText(const QString &statusText);
@@ -81,10 +98,16 @@ private:
     QPointer<QNetworkReply> m_currentReply;
     ChatStreamEventParser m_parser;
     QVariantList m_messages;
-    // Phase 2.1 plumbing: accumulate streamed deltas before pushing to m_messages.
-    // Phase 2.3 will gate this buffer on PetRuntime animation boundaries; for now
-    // every Feed flushes immediately, matching the previous direct-append behavior.
+    // Phase 2.3.1: while m_phase is BUFFERING_FOR_START or GATED, streamed
+    // text accumulates here. On transition to STREAMING, it drains into the
+    // pacer. See docs/v2/设计方案/AI 聊天动画编排设计.md §5.
     QString m_holdBuffer;
+    ChatPhase m_phase = ChatPhase::IDLE;
+    QString m_pendingState;
+    QString m_pendingExpression;
+    ChatTextPacer *m_pacer = nullptr;
+    QTimer m_gateTimeout;
+    static constexpr int kGateTimeoutMs = 800;
     bool m_sidecarReady = false;
     bool m_sending = false;
     bool m_sidecarRestartPending = false;

--- a/apps/desktop/src/chat/ChatController.h
+++ b/apps/desktop/src/chat/ChatController.h
@@ -68,8 +68,6 @@ signals:
 private:
     QVariantMap messageObject(const QString &role, const QString &text, bool pending, bool error) const;
     void appendMessage(const QVariantMap &message);
-    void appendAssistantDelta(const QString &delta);
-    void flushHoldBuffer();
     void transitionTo(ChatPhase next);
     void handleCleanFinishReady();
     void handleBoundaryReached();

--- a/apps/desktop/src/chat/ChatTextPacer.cpp
+++ b/apps/desktop/src/chat/ChatTextPacer.cpp
@@ -38,6 +38,10 @@ void ChatTextPacer::setMsPerChar(int value)
 
 int ChatTextPacer::effectiveInterval() const
 {
+    if (m_queue.size() > kMaxBacklog) {
+        const int sped = static_cast<int>(m_msPerChar * kBacklogSpeedupFactor);
+        return sped < 1 ? 1 : sped;
+    }
     return m_msPerChar;
 }
 
@@ -63,5 +67,11 @@ void ChatTextPacer::tick()
 
     if (m_queue.isEmpty()) {
         m_timer.stop();
+        return;
+    }
+
+    const int next = effectiveInterval();
+    if (m_timer.interval() != next) {
+        m_timer.start(next);
     }
 }

--- a/apps/desktop/src/chat/ChatTextPacer.cpp
+++ b/apps/desktop/src/chat/ChatTextPacer.cpp
@@ -40,6 +40,16 @@ void ChatTextPacer::setMsPerChar(int value)
     }
 }
 
+void ChatTextPacer::discardBeforeStream(quint64 streamId)
+{
+    for (qsizetype i = m_queue.size() - 1; i >= 0; --i) {
+        if (m_queue.at(i).streamId < streamId) {
+            m_queue.removeAt(i);
+        }
+    }
+    stopIfEmpty();
+}
+
 int ChatTextPacer::effectiveInterval() const
 {
     if (queuedCharCount() > kMaxBacklog) {
@@ -82,6 +92,13 @@ void ChatTextPacer::tick()
     const int next = effectiveInterval();
     if (m_timer.interval() != next) {
         m_timer.start(next);
+    }
+}
+
+void ChatTextPacer::stopIfEmpty()
+{
+    if (isEmpty()) {
+        m_timer.stop();
     }
 }
 

--- a/apps/desktop/src/chat/ChatTextPacer.cpp
+++ b/apps/desktop/src/chat/ChatTextPacer.cpp
@@ -9,13 +9,17 @@ ChatTextPacer::ChatTextPacer(QObject *parent)
     connect(&m_timer, &QTimer::timeout, this, &ChatTextPacer::tick);
 }
 
-void ChatTextPacer::append(const QString &text)
+void ChatTextPacer::append(const QString &text, quint64 streamId)
 {
     if (text.isEmpty()) {
         return;
     }
 
-    m_queue.append(text);
+    if (!m_queue.isEmpty() && m_queue.last().streamId == streamId) {
+        m_queue.last().text.append(text);
+    } else {
+        m_queue.append(QueuedChunk{text, streamId});
+    }
     if (!m_timer.isActive()) {
         m_timer.start(effectiveInterval());
     }
@@ -38,7 +42,7 @@ void ChatTextPacer::setMsPerChar(int value)
 
 int ChatTextPacer::effectiveInterval() const
 {
-    if (m_queue.size() > kMaxBacklog) {
+    if (queuedCharCount() > kMaxBacklog) {
         const int sped = static_cast<int>(m_msPerChar * kBacklogSpeedupFactor);
         return sped < 1 ? 1 : sped;
     }
@@ -47,25 +51,30 @@ int ChatTextPacer::effectiveInterval() const
 
 void ChatTextPacer::tick()
 {
-    if (m_queue.isEmpty()) {
+    if (isEmpty()) {
         m_timer.stop();
         return;
     }
 
+    QueuedChunk &front = m_queue.first();
     int popCount = 1;
-    const QChar first = m_queue.at(0);
-    if (first.isHighSurrogate() && m_queue.size() >= 2) {
-        const QChar second = m_queue.at(1);
+    const QChar first = front.text.at(0);
+    if (first.isHighSurrogate() && front.text.size() >= 2) {
+        const QChar second = front.text.at(1);
         if (second.isLowSurrogate()) {
             popCount = 2;
         }
     }
 
-    const QString chunk = m_queue.left(popCount);
-    m_queue.remove(0, popCount);
-    emit chunkReady(chunk);
+    const QString chunk = front.text.left(popCount);
+    const quint64 streamId = front.streamId;
+    front.text.remove(0, popCount);
+    if (front.text.isEmpty()) {
+        m_queue.removeFirst();
+    }
+    emit chunkReady(chunk, streamId);
 
-    if (m_queue.isEmpty()) {
+    if (isEmpty()) {
         m_timer.stop();
         return;
     }
@@ -74,4 +83,18 @@ void ChatTextPacer::tick()
     if (m_timer.interval() != next) {
         m_timer.start(next);
     }
+}
+
+bool ChatTextPacer::isEmpty() const
+{
+    return m_queue.isEmpty() || queuedCharCount() == 0;
+}
+
+qsizetype ChatTextPacer::queuedCharCount() const
+{
+    qsizetype total = 0;
+    for (const QueuedChunk &chunk : m_queue) {
+        total += chunk.text.size();
+    }
+    return total;
 }

--- a/apps/desktop/src/chat/ChatTextPacer.cpp
+++ b/apps/desktop/src/chat/ChatTextPacer.cpp
@@ -1,0 +1,67 @@
+#include "chat/ChatTextPacer.h"
+
+#include <QChar>
+
+ChatTextPacer::ChatTextPacer(QObject *parent)
+    : QObject(parent)
+{
+    m_timer.setSingleShot(false);
+    connect(&m_timer, &QTimer::timeout, this, &ChatTextPacer::tick);
+}
+
+void ChatTextPacer::append(const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+
+    m_queue.append(text);
+    if (!m_timer.isActive()) {
+        m_timer.start(effectiveInterval());
+    }
+}
+
+void ChatTextPacer::setMsPerChar(int value)
+{
+    if (value < 1) {
+        value = 1;
+    }
+    if (value == m_msPerChar) {
+        return;
+    }
+
+    m_msPerChar = value;
+    if (m_timer.isActive()) {
+        m_timer.start(effectiveInterval());
+    }
+}
+
+int ChatTextPacer::effectiveInterval() const
+{
+    return m_msPerChar;
+}
+
+void ChatTextPacer::tick()
+{
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+        return;
+    }
+
+    int popCount = 1;
+    const QChar first = m_queue.at(0);
+    if (first.isHighSurrogate() && m_queue.size() >= 2) {
+        const QChar second = m_queue.at(1);
+        if (second.isLowSurrogate()) {
+            popCount = 2;
+        }
+    }
+
+    const QString chunk = m_queue.left(popCount);
+    m_queue.remove(0, popCount);
+    emit chunkReady(chunk);
+
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+    }
+}

--- a/apps/desktop/src/chat/ChatTextPacer.h
+++ b/apps/desktop/src/chat/ChatTextPacer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+// ChatTextPacer drives streamed text into the UI at a human reading rate.
+// See docs/v2/设计方案/AI 聊天动画编排设计.md §7.
+class ChatTextPacer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ChatTextPacer(QObject *parent = nullptr);
+
+    void append(const QString &text);
+
+    int msPerChar() const { return m_msPerChar; }
+    void setMsPerChar(int value);
+
+    int pendingCount() const { return m_queue.size(); }
+
+signals:
+    void chunkReady(const QString &chunk);
+
+private:
+    void tick();
+    int effectiveInterval() const;
+
+    QString m_queue;
+    QTimer m_timer;
+    int m_msPerChar = 80;
+
+    static constexpr int kMaxBacklog = 30;
+    static constexpr double kBacklogSpeedupFactor = 0.5;
+};

--- a/apps/desktop/src/chat/ChatTextPacer.h
+++ b/apps/desktop/src/chat/ChatTextPacer.h
@@ -13,21 +13,28 @@ class ChatTextPacer : public QObject
 public:
     explicit ChatTextPacer(QObject *parent = nullptr);
 
-    void append(const QString &text);
+    void append(const QString &text, quint64 streamId = 0);
 
     int msPerChar() const { return m_msPerChar; }
     void setMsPerChar(int value);
 
-    int pendingCount() const { return m_queue.size(); }
+    int pendingCount() const { return static_cast<int>(queuedCharCount()); }
 
 signals:
-    void chunkReady(const QString &chunk);
+    void chunkReady(const QString &chunk, quint64 streamId);
 
 private:
+    struct QueuedChunk {
+        QString text;
+        quint64 streamId = 0;
+    };
+
     void tick();
     int effectiveInterval() const;
+    bool isEmpty() const;
+    qsizetype queuedCharCount() const;
 
-    QString m_queue;
+    QList<QueuedChunk> m_queue;
     QTimer m_timer;
     int m_msPerChar = 80;
 

--- a/apps/desktop/src/chat/ChatTextPacer.h
+++ b/apps/desktop/src/chat/ChatTextPacer.h
@@ -14,6 +14,7 @@ public:
     explicit ChatTextPacer(QObject *parent = nullptr);
 
     void append(const QString &text, quint64 streamId = 0);
+    void discardBeforeStream(quint64 streamId);
 
     int msPerChar() const { return m_msPerChar; }
     void setMsPerChar(int value);
@@ -31,6 +32,7 @@ private:
 
     void tick();
     int effectiveInterval() const;
+    void stopIfEmpty();
     bool isEmpty() const;
     qsizetype queuedCharCount() const;
 

--- a/apps/desktop/src/logging/MilesLogHandler.cpp
+++ b/apps/desktop/src/logging/MilesLogHandler.cpp
@@ -1,0 +1,135 @@
+#include "logging/MilesLogHandler.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QMessageLogContext>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QTextStream>
+
+#include <cstdio>
+#include <memory>
+
+namespace {
+
+QtMessageHandler previousHandler = nullptr;
+QMutex logMutex;
+std::unique_ptr<QFile> logFile;
+
+QString levelName(QtMsgType type)
+{
+    switch (type) {
+    case QtDebugMsg:
+        return QStringLiteral("DEBUG");
+    case QtInfoMsg:
+        return QStringLiteral("INFO ");
+    case QtWarningMsg:
+        return QStringLiteral("WARN ");
+    case QtCriticalMsg:
+    case QtFatalMsg:
+        return QStringLiteral("ERROR");
+    }
+    return QStringLiteral("INFO ");
+}
+
+QString sourceName(const QMessageLogContext &context)
+{
+    if (context.file == nullptr || context.line <= 0) {
+        return QString();
+    }
+    return QFileInfo(QString::fromUtf8(context.file)).fileName()
+        + QStringLiteral(":")
+        + QString::number(context.line);
+}
+
+void writeStderr(const QString &line)
+{
+    const QByteArray bytes = line.toLocal8Bit();
+    std::fwrite(bytes.constData(), 1, static_cast<size_t>(bytes.size()), stderr);
+    std::fwrite("\n", 1, 1, stderr);
+    std::fflush(stderr);
+}
+
+void writeFileLine(const QString &line)
+{
+    if (logFile == nullptr || !logFile->isOpen()) {
+        return;
+    }
+
+    QTextStream stream(logFile.get());
+    stream << line << '\n';
+    stream.flush();
+}
+
+void handleMessage(QtMsgType type, const QMessageLogContext &context, const QString &message)
+{
+    QMutexLocker locker(&logMutex);
+    if (MilesLogHandler::isMilesCategory(context.category)) {
+        writeStderr(MilesLogHandler::formatMilesMessage(type, context, message, false));
+        writeFileLine(MilesLogHandler::formatMilesMessage(type, context, message, true));
+        return;
+    }
+
+    const QString defaultLine = qFormatLogMessage(type, context, message);
+    if (previousHandler != nullptr) {
+        previousHandler(type, context, message);
+    } else {
+        writeStderr(defaultLine);
+    }
+
+    writeFileLine(defaultLine);
+}
+
+} // namespace
+
+namespace MilesLogHandler {
+
+void install()
+{
+    const QByteArray path = qgetenv("MILES_LOG_FILE").trimmed();
+    if (!path.isEmpty()) {
+        logFile = std::make_unique<QFile>(QString::fromLocal8Bit(path));
+        if (!logFile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+            logFile.reset();
+        }
+    }
+
+    previousHandler = qInstallMessageHandler(handleMessage);
+}
+
+bool isMilesCategory(const char *category)
+{
+    if (category == nullptr) {
+        return false;
+    }
+    return QByteArray(category).startsWith("miles.");
+}
+
+QString formatMilesMessage(QtMsgType type,
+                           const QMessageLogContext &context,
+                           const QString &message,
+                           bool includeDate)
+{
+    const QString timestamp = QDateTime::currentDateTime().toString(
+        includeDate ? QStringLiteral("yyyy-MM-dd HH:mm:ss.zzz") : QStringLiteral("HH:mm:ss.zzz"));
+    const QString category = QString::fromUtf8(context.category == nullptr ? "miles.app" : context.category)
+        .toUpper();
+    QString line = timestamp
+        + QStringLiteral(" ")
+        + levelName(type)
+        + QStringLiteral(" [")
+        + category
+        + QStringLiteral("] ")
+        + message;
+
+    const QString source = sourceName(context);
+    if (!source.isEmpty()) {
+        line += QStringLiteral(" [") + source + QStringLiteral("]");
+    }
+    return line;
+}
+
+} // namespace MilesLogHandler

--- a/apps/desktop/src/logging/MilesLogHandler.cpp
+++ b/apps/desktop/src/logging/MilesLogHandler.cpp
@@ -9,6 +9,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <QTextStream>
+#include <QtLogging>
 
 #include <cstdio>
 #include <memory>
@@ -18,6 +19,7 @@ namespace {
 QtMessageHandler previousHandler = nullptr;
 QMutex logMutex;
 std::unique_ptr<QFile> logFile;
+bool installed = false;
 
 QString levelName(QtMsgType type)
 {
@@ -53,8 +55,17 @@ void writeStderr(const QString &line)
     std::fflush(stderr);
 }
 
+void writeDiagnostic(const QString &message)
+{
+    const QByteArray bytes = message.toLocal8Bit();
+    std::fwrite(bytes.constData(), 1, static_cast<size_t>(bytes.size()), stderr);
+    std::fwrite("\n", 1, 1, stderr);
+    std::fflush(stderr);
+}
+
 void writeFileLine(const QString &line)
 {
+    QMutexLocker locker(&logMutex);
     if (logFile == nullptr || !logFile->isOpen()) {
         return;
     }
@@ -66,7 +77,6 @@ void writeFileLine(const QString &line)
 
 void handleMessage(QtMsgType type, const QMessageLogContext &context, const QString &message)
 {
-    QMutexLocker locker(&logMutex);
     if (MilesLogHandler::isMilesCategory(context.category)) {
         writeStderr(MilesLogHandler::formatMilesMessage(type, context, message, false));
         writeFileLine(MilesLogHandler::formatMilesMessage(type, context, message, true));
@@ -74,8 +84,14 @@ void handleMessage(QtMsgType type, const QMessageLogContext &context, const QStr
     }
 
     const QString defaultLine = qFormatLogMessage(type, context, message);
-    if (previousHandler != nullptr) {
-        previousHandler(type, context, message);
+    QtMessageHandler handler = nullptr;
+    {
+        QMutexLocker locker(&logMutex);
+        handler = previousHandler;
+    }
+
+    if (handler != nullptr) {
+        handler(type, context, message);
     } else {
         writeStderr(defaultLine);
     }
@@ -89,15 +105,31 @@ namespace MilesLogHandler {
 
 void install()
 {
+    QMutexLocker locker(&logMutex);
+    if (installed) {
+        return;
+    }
+
     const QByteArray path = qgetenv("MILES_LOG_FILE").trimmed();
     if (!path.isEmpty()) {
-        logFile = std::make_unique<QFile>(QString::fromLocal8Bit(path));
-        if (!logFile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        const QString filePath = QString::fromLocal8Bit(path);
+        QFile truncateFile(filePath);
+        if (!truncateFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+            writeDiagnostic(QStringLiteral("MilesLogHandler: failed to truncate MILES_LOG_FILE: ") + filePath);
+        } else {
+            truncateFile.close();
+            logFile = std::make_unique<QFile>(filePath);
+        }
+
+        if (logFile != nullptr
+            && !logFile->open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+            writeDiagnostic(QStringLiteral("MilesLogHandler: failed to append MILES_LOG_FILE: ") + filePath);
             logFile.reset();
         }
     }
 
     previousHandler = qInstallMessageHandler(handleMessage);
+    installed = true;
 }
 
 bool isMilesCategory(const char *category)

--- a/apps/desktop/src/logging/MilesLogHandler.h
+++ b/apps/desktop/src/logging/MilesLogHandler.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QtGlobal>
+
+class QMessageLogContext;
+class QString;
+
+namespace MilesLogHandler {
+
+void install();
+bool isMilesCategory(const char *category);
+QString formatMilesMessage(QtMsgType type,
+                           const QMessageLogContext &context,
+                           const QString &message,
+                           bool includeDate);
+
+} // namespace MilesLogHandler

--- a/apps/desktop/src/logging/MilesLogHandler.h
+++ b/apps/desktop/src/logging/MilesLogHandler.h
@@ -1,9 +1,8 @@
 #pragma once
 
+#include <QMessageLogContext>
+#include <QString>
 #include <QtGlobal>
-
-class QMessageLogContext;
-class QString;
 
 namespace MilesLogHandler {
 

--- a/apps/desktop/src/main.cpp
+++ b/apps/desktop/src/main.cpp
@@ -1,5 +1,6 @@
 #include "DesktopShellController.h"
 #include "chat/ChatController.h"
+#include "logging/MilesLogHandler.h"
 #include "pet/events/PetEventBridge.h"
 #include "pet/interaction/CustomInteractionRegistry.h"
 #include "pet/PetRuntime.h"
@@ -24,6 +25,8 @@
 
 int main(int argc, char *argv[])
 {
+    MilesLogHandler::install();
+
     // Qt.labs.platform 的原生菜单在部分平台需要 Qt Widgets fallback。
     // 因此桌面壳层使用 QApplication，而不是更轻的 QGuiApplication。
     QApplication app(argc, argv);

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -217,8 +217,8 @@ void PetRuntime::playActionFromPool(const QString &poolId)
 void PetRuntime::submitActionRequest(const ActionRequest &request)
 {
     if (request.kind == ActionRequestKind::None) {
-        qCDebug(petRuntimeLog) << "ignore empty action request"
-                               << "hideCurrentProp=" << request.hideCurrentProp;
+        qCDebug(petRuntimeLog).noquote() << "ignore empty action request"
+                                          << QStringLiteral("hideCurrentProp=%1").arg(request.hideCurrentProp);
         if (request.hideCurrentProp) {
             executeActionRequest(request);
         }
@@ -226,10 +226,10 @@ void PetRuntime::submitActionRequest(const ActionRequest &request)
     }
 
     if (request.interruptHint == InterruptHint::AfterCurrent && shouldDeferActionRequest(request)) {
-        qCDebug(petRuntimeLog) << "defer action request"
-                               << "kind=" << static_cast<int>(request.kind)
-                               << "target=" << request.targetId
-                               << "state=" << request.petState;
+        qCDebug(petRuntimeLog).noquote() << "defer action request"
+                                          << QStringLiteral("kind=%1").arg(static_cast<int>(request.kind))
+                                          << QStringLiteral("target=%1").arg(request.targetId)
+                                          << QStringLiteral("state=%1").arg(request.petState);
         m_pendingRequest = request;
         return;
     }
@@ -243,11 +243,11 @@ void PetRuntime::submitActionRequest(const ActionRequest &request)
 
 void PetRuntime::executeActionRequest(const ActionRequest &request)
 {
-    qCDebug(petRuntimeLog) << "execute action request"
-                           << "kind=" << static_cast<int>(request.kind)
-                           << "target=" << request.targetId
-                           << "state=" << request.petState
-                           << "interruptHint=" << static_cast<int>(request.interruptHint);
+    qCDebug(petRuntimeLog).noquote() << "execute action request"
+                                      << QStringLiteral("kind=%1").arg(static_cast<int>(request.kind))
+                                      << QStringLiteral("target=%1").arg(request.targetId)
+                                      << QStringLiteral("state=%1").arg(request.petState)
+                                      << QStringLiteral("interruptHint=%1").arg(static_cast<int>(request.interruptHint));
     if (request.hideCurrentProp) {
         hideCurrentProp();
     }
@@ -374,12 +374,12 @@ void PetRuntime::submitExpressionRequest(
         emit currentStateChanged();
     }
 
-    qCDebug(petExpressionLog) << "submit expression request"
-                              << "requestedState=" << requestedState
-                              << "eventState=" << eventState
-                              << "expression=" << expression
-                              << "interruptHint=" << static_cast<int>(interruptHint)
-                              << "currentAction=" << m_currentActionId;
+    qCDebug(petExpressionLog).noquote() << "submit expression request"
+                                         << QStringLiteral("requestedState=%1").arg(requestedState)
+                                         << QStringLiteral("eventState=%1").arg(eventState)
+                                         << QStringLiteral("expression=%1").arg(expression)
+                                         << QStringLiteral("interruptHint=%1").arg(static_cast<int>(interruptHint))
+                                         << QStringLiteral("currentAction=%1").arg(m_currentActionId);
     submitRuntimeEvent(PetEvent::agentExpressionRequested(eventState, expression, randomValue, interruptHint));
 }
 
@@ -433,10 +433,10 @@ void PetRuntime::playActionInternal(const QString &actionId, bool resetRecipe)
         clearActiveRecipe();
     }
 
-    qCDebug(petRuntimeLog) << "play action"
-                           << "requested=" << actionId
-                           << "resolved=" << nextActionId
-                           << "resetRecipe=" << resetRecipe;
+    qCDebug(petRuntimeLog).noquote() << "play action"
+                                      << QStringLiteral("requested=%1").arg(actionId)
+                                      << QStringLiteral("resolved=%1").arg(nextActionId)
+                                      << QStringLiteral("resetRecipe=%1").arg(resetRecipe);
     setCurrentAction(nextActionId, m_manifest.actions.value(nextActionId));
 }
 
@@ -807,13 +807,13 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
     m_currentAutoReturnToIdle = nextAutoReturnToIdle;
     m_currentAnimationUrl = nextAnimationUrl;
     ++m_playbackSerial;
-    qCDebug(petRuntimeLog) << "set current phase"
-                           << "action=" << actionId
-                           << "phase=" << nextPhaseId
-                           << "loopMode=" << nextLoopMode
-                           << "url=" << nextAnimationUrl
-                           << "serial=" << m_playbackSerial
-                           << "replacing=" << replacingActiveAnimation;
+    qCDebug(petRuntimeLog).noquote() << "set current phase"
+                                      << QStringLiteral("action=%1").arg(actionId)
+                                      << QStringLiteral("phase=%1").arg(nextPhaseId)
+                                      << QStringLiteral("loopMode=%1").arg(nextLoopMode)
+                                      << QStringLiteral("url=%1").arg(nextAnimationUrl.toString())
+                                      << QStringLiteral("serial=%1").arg(m_playbackSerial)
+                                      << QStringLiteral("replacing=%1").arg(replacingActiveAnimation);
 
     if (actionChanged) {
         emit currentActionChanged();

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -4,6 +4,7 @@
 #include "pet/manifest/SkinManifestLoader.h"
 #include "pet/selection/ActionPoolSelector.h"
 
+#include <QLoggingCategory>
 #include <QRandomGenerator>
 #include <QSettings>
 #include <QTimer>
@@ -13,6 +14,9 @@
 #include <utility>
 
 namespace {
+Q_LOGGING_CATEGORY(petRuntimeLog, "miles.pet.runtime")
+Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression")
+
 constexpr auto kFallbackAnimationUrl = "qrc:/pet/stand-right.gif";
 constexpr int kBoundarySafetyMs = 1500;
 } // namespace
@@ -213,6 +217,8 @@ void PetRuntime::playActionFromPool(const QString &poolId)
 void PetRuntime::submitActionRequest(const ActionRequest &request)
 {
     if (request.kind == ActionRequestKind::None) {
+        qCDebug(petRuntimeLog) << "ignore empty action request"
+                               << "hideCurrentProp=" << request.hideCurrentProp;
         if (request.hideCurrentProp) {
             executeActionRequest(request);
         }
@@ -220,6 +226,10 @@ void PetRuntime::submitActionRequest(const ActionRequest &request)
     }
 
     if (request.interruptHint == InterruptHint::AfterCurrent && shouldDeferActionRequest(request)) {
+        qCDebug(petRuntimeLog) << "defer action request"
+                               << "kind=" << static_cast<int>(request.kind)
+                               << "target=" << request.targetId
+                               << "state=" << request.petState;
         m_pendingRequest = request;
         return;
     }
@@ -233,6 +243,11 @@ void PetRuntime::submitActionRequest(const ActionRequest &request)
 
 void PetRuntime::executeActionRequest(const ActionRequest &request)
 {
+    qCDebug(petRuntimeLog) << "execute action request"
+                           << "kind=" << static_cast<int>(request.kind)
+                           << "target=" << request.targetId
+                           << "state=" << request.petState
+                           << "interruptHint=" << static_cast<int>(request.interruptHint);
     if (request.hideCurrentProp) {
         hideCurrentProp();
     }
@@ -359,6 +374,12 @@ void PetRuntime::submitExpressionRequest(
         emit currentStateChanged();
     }
 
+    qCDebug(petExpressionLog) << "submit expression request"
+                              << "requestedState=" << requestedState
+                              << "eventState=" << eventState
+                              << "expression=" << expression
+                              << "interruptHint=" << static_cast<int>(interruptHint)
+                              << "currentAction=" << m_currentActionId;
     submitRuntimeEvent(PetEvent::agentExpressionRequested(eventState, expression, randomValue, interruptHint));
 }
 
@@ -412,6 +433,10 @@ void PetRuntime::playActionInternal(const QString &actionId, bool resetRecipe)
         clearActiveRecipe();
     }
 
+    qCDebug(petRuntimeLog) << "play action"
+                           << "requested=" << actionId
+                           << "resolved=" << nextActionId
+                           << "resetRecipe=" << resetRecipe;
     setCurrentAction(nextActionId, m_manifest.actions.value(nextActionId));
 }
 
@@ -779,6 +804,13 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
     m_currentAutoReturnToIdle = nextAutoReturnToIdle;
     m_currentAnimationUrl = nextAnimationUrl;
     ++m_playbackSerial;
+    qCDebug(petRuntimeLog) << "set current phase"
+                           << "action=" << actionId
+                           << "phase=" << nextPhaseId
+                           << "loopMode=" << nextLoopMode
+                           << "url=" << nextAnimationUrl
+                           << "serial=" << m_playbackSerial
+                           << "replacing=" << replacingActiveAnimation;
 
     if (actionChanged) {
         emit currentActionChanged();

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -19,6 +19,11 @@ Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression", QtInfoMsg)
 
 constexpr auto kFallbackAnimationUrl = "qrc:/pet/stand-right.gif";
 constexpr int kBoundarySafetyMs = 1500;
+
+QString logBool(bool value)
+{
+    return value ? QStringLiteral("true") : QStringLiteral("false");
+}
 } // namespace
 
 PetRuntime::PetRuntime(QObject *parent)
@@ -218,7 +223,7 @@ void PetRuntime::submitActionRequest(const ActionRequest &request)
 {
     if (request.kind == ActionRequestKind::None) {
         qCDebug(petRuntimeLog).noquote() << "ignore empty action request"
-                                          << QStringLiteral("hideCurrentProp=%1").arg(request.hideCurrentProp);
+                                          << QStringLiteral("hideCurrentProp=%1").arg(logBool(request.hideCurrentProp));
         if (request.hideCurrentProp) {
             executeActionRequest(request);
         }
@@ -436,7 +441,7 @@ void PetRuntime::playActionInternal(const QString &actionId, bool resetRecipe)
     qCDebug(petRuntimeLog).noquote() << "play action"
                                       << QStringLiteral("requested=%1").arg(actionId)
                                       << QStringLiteral("resolved=%1").arg(nextActionId)
-                                      << QStringLiteral("resetRecipe=%1").arg(resetRecipe);
+                                      << QStringLiteral("resetRecipe=%1").arg(logBool(resetRecipe));
     setCurrentAction(nextActionId, m_manifest.actions.value(nextActionId));
 }
 
@@ -813,7 +818,7 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
                                       << QStringLiteral("loopMode=%1").arg(nextLoopMode)
                                       << QStringLiteral("url=%1").arg(nextAnimationUrl.toString())
                                       << QStringLiteral("serial=%1").arg(m_playbackSerial)
-                                      << QStringLiteral("replacing=%1").arg(replacingActiveAnimation);
+                                      << QStringLiteral("replacing=%1").arg(logBool(replacingActiveAnimation));
 
     if (actionChanged) {
         emit currentActionChanged();

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -14,6 +14,7 @@
 
 namespace {
 constexpr auto kFallbackAnimationUrl = "qrc:/pet/stand-right.gif";
+constexpr int kBoundarySafetyMs = 1500;
 } // namespace
 
 PetRuntime::PetRuntime(QObject *parent)
@@ -444,9 +445,7 @@ void PetRuntime::handleAnimationFinished()
         return;
     }
 
-    if (drainPendingNotifications()) {
-        return;
-    }
+    drainPendingNotifications();
 
     applyFacingAfterCurrentAction(action);
 
@@ -802,9 +801,6 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
     }
     emit playbackSerialChanged();
 
-    if (atAnimationBoundary()) {
-        drainPendingNotifications();
-    }
 }
 
 bool PetRuntime::atAnimationBoundary() const
@@ -847,7 +843,7 @@ void PetRuntime::enqueueBoundaryNotification(std::function<void()> callback)
         triggerPendingNotification(notificationId);
     });
 
-    notification.timer->start(1500);
+    notification.timer->start(kBoundarySafetyMs);
     m_pendingNotifications.append(std::move(notification));
 }
 

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -755,6 +755,13 @@ void PetRuntime::setCurrentAction(const QString &actionId, const ActionDefinitio
 
 void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId, const PhaseDefinition &phase)
 {
+    const bool replacingActiveAnimation = !m_currentActionId.isEmpty()
+        && (m_currentActionId != actionId || m_currentPhaseId != phaseId);
+
+    if (replacingActiveAnimation) {
+        drainPendingNotifications();
+    }
+
     const bool wasPointerInteractionEnabled = pointerInteractionEnabled();
     const bool wasSleeping = sleeping();
     const bool wasSleepTransitioning = sleepTransitioning();

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -758,10 +758,6 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
     const bool replacingActiveAnimation = !m_currentActionId.isEmpty()
         && (m_currentActionId != actionId || m_currentPhaseId != phaseId);
 
-    if (replacingActiveAnimation) {
-        drainPendingNotifications();
-    }
-
     const bool wasPointerInteractionEnabled = pointerInteractionEnabled();
     const bool wasSleeping = sleeping();
     const bool wasSleepTransitioning = sleepTransitioning();
@@ -808,6 +804,9 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
     }
     emit playbackSerialChanged();
 
+    if (replacingActiveAnimation) {
+        drainPendingNotifications();
+    }
 }
 
 bool PetRuntime::atAnimationBoundary() const

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -14,8 +14,8 @@
 #include <utility>
 
 namespace {
-Q_LOGGING_CATEGORY(petRuntimeLog, "miles.pet.runtime")
-Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression")
+Q_LOGGING_CATEGORY(petRuntimeLog, "miles.pet.runtime", QtInfoMsg)
+Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression", QtInfoMsg)
 
 constexpr auto kFallbackAnimationUrl = "qrc:/pet/stand-right.gif";
 constexpr int kBoundarySafetyMs = 1500;
@@ -463,6 +463,7 @@ void PetRuntime::returnToIdle()
 
 void PetRuntime::handleAnimationFinished()
 {
+    const int finishingPlaybackSerial = m_playbackSerial;
     const ActionDefinition action = m_manifest.actions.value(m_currentActionId);
     const PhaseDefinition phase = action.phases.value(m_currentPhaseId);
     if (!phase.nextPhase.isEmpty() && action.phases.contains(phase.nextPhase)) {
@@ -470,7 +471,9 @@ void PetRuntime::handleAnimationFinished()
         return;
     }
 
-    drainPendingNotifications();
+    if (drainPendingNotifications() && m_playbackSerial != finishingPlaybackSerial) {
+        return;
+    }
 
     applyFacingAfterCurrentAction(action);
 

--- a/apps/desktop/src/pet/PetRuntime.cpp
+++ b/apps/desktop/src/pet/PetRuntime.cpp
@@ -6,8 +6,11 @@
 
 #include <QRandomGenerator>
 #include <QSettings>
+#include <QTimer>
 #include <QtGlobal>
 #include <QVariantMap>
+
+#include <utility>
 
 namespace {
 constexpr auto kFallbackAnimationUrl = "qrc:/pet/stand-right.gif";
@@ -358,6 +361,16 @@ void PetRuntime::submitExpressionRequest(
     submitRuntimeEvent(PetEvent::agentExpressionRequested(eventState, expression, randomValue, interruptHint));
 }
 
+void PetRuntime::requestBoundaryAndNotify(std::function<void()> callback)
+{
+    enqueueBoundaryNotification(std::move(callback));
+}
+
+void PetRuntime::requestCleanFinishAndNotify(std::function<void()> callback)
+{
+    enqueueBoundaryNotification(std::move(callback));
+}
+
 QVariantMap PetRuntime::consumeFrameMovementDelta() const
 {
     QVariantMap delta;
@@ -428,6 +441,10 @@ void PetRuntime::handleAnimationFinished()
     const PhaseDefinition phase = action.phases.value(m_currentPhaseId);
     if (!phase.nextPhase.isEmpty() && action.phases.contains(phase.nextPhase)) {
         playPhase(m_currentActionId, phase.nextPhase);
+        return;
+    }
+
+    if (drainPendingNotifications()) {
         return;
     }
 
@@ -784,4 +801,101 @@ void PetRuntime::setCurrentPhase(const QString &actionId, const QString &phaseId
         emit sleepStateChanged();
     }
     emit playbackSerialChanged();
+
+    if (atAnimationBoundary()) {
+        drainPendingNotifications();
+    }
+}
+
+bool PetRuntime::atAnimationBoundary() const
+{
+    if (m_currentActionId.isEmpty()) {
+        return true;
+    }
+
+    const QString idleAction = actionForState(QStringLiteral("idle"));
+    if (m_currentRecipeId.isEmpty()
+            && m_currentState == QStringLiteral("idle")
+            && !idleAction.isEmpty()
+            && m_currentActionId == idleAction) {
+        return true;
+    }
+
+    return m_currentLoopMode == QStringLiteral("hold")
+        || m_currentLoopMode == QStringLiteral("onceThenHold");
+}
+
+void PetRuntime::enqueueBoundaryNotification(std::function<void()> callback)
+{
+    if (!callback) {
+        return;
+    }
+
+    if (atAnimationBoundary()) {
+        callback();
+        return;
+    }
+
+    PendingNotification notification;
+    notification.id = ++m_nextPendingNotificationId;
+    notification.callback = std::move(callback);
+    notification.timer = new QTimer(this);
+    notification.timer->setSingleShot(true);
+
+    const quint64 notificationId = notification.id;
+    connect(notification.timer, &QTimer::timeout, this, [this, notificationId]() {
+        triggerPendingNotification(notificationId);
+    });
+
+    notification.timer->start(1500);
+    m_pendingNotifications.append(std::move(notification));
+}
+
+bool PetRuntime::drainPendingNotifications()
+{
+    if (m_pendingNotifications.isEmpty()) {
+        return false;
+    }
+
+    QList<PendingNotification> notifications = std::move(m_pendingNotifications);
+    m_pendingNotifications.clear();
+
+    for (PendingNotification &notification : notifications) {
+        if (notification.timer != nullptr) {
+            notification.timer->stop();
+            notification.timer->deleteLater();
+            notification.timer = nullptr;
+        }
+    }
+
+    for (PendingNotification &notification : notifications) {
+        if (notification.callback) {
+            notification.callback();
+        }
+    }
+
+    return true;
+}
+
+bool PetRuntime::triggerPendingNotification(quint64 notificationId)
+{
+    for (qsizetype index = 0; index < m_pendingNotifications.size(); ++index) {
+        if (m_pendingNotifications.at(index).id != notificationId) {
+            continue;
+        }
+
+        PendingNotification notification = std::move(m_pendingNotifications[index]);
+        m_pendingNotifications.removeAt(index);
+        if (notification.timer != nullptr) {
+            notification.timer->stop();
+            notification.timer->deleteLater();
+            notification.timer = nullptr;
+        }
+        if (notification.callback) {
+            notification.callback();
+        }
+        return true;
+    }
+
+    return false;
 }

--- a/apps/desktop/src/pet/PetRuntime.h
+++ b/apps/desktop/src/pet/PetRuntime.h
@@ -21,6 +21,10 @@
 #include <QVariantMap>
 #include <QtQml/qqmlregistration.h>
 
+#include <functional>
+
+class QTimer;
+
 // PetRuntime 是 v2 桌宠动画系统的执行入口。
 //
 // 它不再理解“单击”“双击”“红茶”这类事件语义；这些语义先进入
@@ -161,6 +165,8 @@ public:
         double randomValue,
         InterruptHint interruptHint
     );
+    void requestBoundaryAndNotify(std::function<void()> callback);
+    void requestCleanFinishAndNotify(std::function<void()> callback);
 
 signals:
     void currentStateChanged();
@@ -213,11 +219,22 @@ private:
     void playPhase(const QString &actionId, const QString &phaseId);
     void setCurrentAction(const QString &actionId, const ActionDefinition &action);
     void setCurrentPhase(const QString &actionId, const QString &phaseId, const PhaseDefinition &phase);
+    bool atAnimationBoundary() const;
+    void enqueueBoundaryNotification(std::function<void()> callback);
+    bool drainPendingNotifications();
+    bool triggerPendingNotification(quint64 notificationId);
     void applyManifestState();
     bool activateSkin(const QString &skinId, bool persistSelection);
     bool loadSkinDescriptor(const SkinDescriptor &descriptor);
     SkinDescriptor descriptorForSkinId(const QString &skinId) const;
     void refreshAvailableSkins();
+
+    struct PendingNotification
+    {
+        quint64 id = 0;
+        std::function<void()> callback;
+        QTimer *timer = nullptr;
+    };
 
     SkinManifest m_manifest;
     QList<SkinDescriptor> m_availableSkinDescriptors;
@@ -239,6 +256,8 @@ private:
     PropController m_propController;
     int m_playbackSerial = 0;
     ActionRequest m_pendingRequest;
+    QList<PendingNotification> m_pendingNotifications;
+    quint64 m_nextPendingNotificationId = 0;
 };
 
 // 与 DesktopShellControllerForeign 一样，这个 wrapper 让 QML 看到一个名为

--- a/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
+++ b/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
@@ -129,18 +129,18 @@ ActionRequest resolveInternal(
 
     const ExpressionMappingDefinition mapping = manifest.expressionMappings.value(resolvedExpressionId);
     const QList<ExpressionMappingEntry> entries = availableEntries(manifest, context, mapping);
-    qCDebug(petExpressionLog) << "resolve expression"
-                              << "requested=" << expressionId
-                              << "resolved=" << resolvedExpressionId
-                              << "state=" << context.state
-                              << "candidates=" << entries.size()
-                              << "selection=" << mapping.selection;
+    qCDebug(petExpressionLog).noquote() << "resolve expression"
+                                         << QStringLiteral("requested=%1").arg(expressionId)
+                                         << QStringLiteral("resolved=%1").arg(resolvedExpressionId)
+                                         << QStringLiteral("state=%1").arg(context.state)
+                                         << QStringLiteral("candidates=%1").arg(entries.size())
+                                         << QStringLiteral("selection=%1").arg(mapping.selection);
     const ActionRequest selectedRequest = selectEntry(context, mapping, entries);
     if (selectedRequest.kind != ActionRequestKind::None) {
-        qCDebug(petExpressionLog) << "expression selected request"
-                                  << "expression=" << resolvedExpressionId
-                                  << "kind=" << static_cast<int>(selectedRequest.kind)
-                                  << "target=" << selectedRequest.targetId;
+        qCDebug(petExpressionLog).noquote() << "expression selected request"
+                                             << QStringLiteral("expression=%1").arg(resolvedExpressionId)
+                                             << QStringLiteral("kind=%1").arg(static_cast<int>(selectedRequest.kind))
+                                             << QStringLiteral("target=%1").arg(selectedRequest.targetId);
         return selectedRequest;
     }
 
@@ -148,14 +148,14 @@ ActionRequest resolveInternal(
         ? QString::fromUtf8(kNeutralExpressionId)
         : mapping.fallbackExpressionId.trimmed();
     if (fallbackExpressionId == resolvedExpressionId) {
-        qCDebug(petExpressionLog) << "expression fallback exhausted"
-                                  << "expression=" << resolvedExpressionId;
+        qCDebug(petExpressionLog).noquote() << "expression fallback exhausted"
+                                             << QStringLiteral("expression=%1").arg(resolvedExpressionId);
         return ActionRequest::none();
     }
 
-    qCDebug(petExpressionLog) << "expression fallback"
-                              << "from=" << resolvedExpressionId
-                              << "to=" << fallbackExpressionId;
+    qCDebug(petExpressionLog).noquote() << "expression fallback"
+                                         << QStringLiteral("from=%1").arg(resolvedExpressionId)
+                                         << QStringLiteral("to=%1").arg(fallbackExpressionId);
     return resolveInternal(manifest, context, fallbackExpressionId, visitedExpressionIds);
 }
 } // namespace

--- a/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
+++ b/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
@@ -5,7 +5,7 @@
 #include <QtGlobal>
 
 namespace {
-Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression")
+Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression", QtInfoMsg)
 
 constexpr auto kNeutralExpressionId = "neutral";
 constexpr auto kFirstAvailableSelection = "first_available";

--- a/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
+++ b/apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp
@@ -1,9 +1,12 @@
 #include "pet/selection/ExpressionMappingResolver.h"
 
+#include <QLoggingCategory>
 #include <QSet>
 #include <QtGlobal>
 
 namespace {
+Q_LOGGING_CATEGORY(petExpressionLog, "miles.pet.expression")
+
 constexpr auto kNeutralExpressionId = "neutral";
 constexpr auto kFirstAvailableSelection = "first_available";
 constexpr auto kWeightedRandomSelection = "weighted_random";
@@ -126,8 +129,18 @@ ActionRequest resolveInternal(
 
     const ExpressionMappingDefinition mapping = manifest.expressionMappings.value(resolvedExpressionId);
     const QList<ExpressionMappingEntry> entries = availableEntries(manifest, context, mapping);
+    qCDebug(petExpressionLog) << "resolve expression"
+                              << "requested=" << expressionId
+                              << "resolved=" << resolvedExpressionId
+                              << "state=" << context.state
+                              << "candidates=" << entries.size()
+                              << "selection=" << mapping.selection;
     const ActionRequest selectedRequest = selectEntry(context, mapping, entries);
     if (selectedRequest.kind != ActionRequestKind::None) {
+        qCDebug(petExpressionLog) << "expression selected request"
+                                  << "expression=" << resolvedExpressionId
+                                  << "kind=" << static_cast<int>(selectedRequest.kind)
+                                  << "target=" << selectedRequest.targetId;
         return selectedRequest;
     }
 
@@ -135,9 +148,14 @@ ActionRequest resolveInternal(
         ? QString::fromUtf8(kNeutralExpressionId)
         : mapping.fallbackExpressionId.trimmed();
     if (fallbackExpressionId == resolvedExpressionId) {
+        qCDebug(petExpressionLog) << "expression fallback exhausted"
+                                  << "expression=" << resolvedExpressionId;
         return ActionRequest::none();
     }
 
+    qCDebug(petExpressionLog) << "expression fallback"
+                              << "from=" << resolvedExpressionId
+                              << "to=" << fallbackExpressionId;
     return resolveInternal(manifest, context, fallbackExpressionId, visitedExpressionIds);
 }
 } // namespace

--- a/apps/desktop/src/pet/surface/PetContextMenu.cpp
+++ b/apps/desktop/src/pet/surface/PetContextMenu.cpp
@@ -36,7 +36,7 @@ void PetContextMenu::show(
     const QPoint &globalPosition
 )
 {
-    QMenu menu(parent);
+    QMenu menu;
 
     const QVariantList availablePetSizes = runtime->availablePetSizes();
     if (!availablePetSizes.isEmpty()) {

--- a/apps/desktop/src/pet/surface/PetSurfaceWindow.cpp
+++ b/apps/desktop/src/pet/surface/PetSurfaceWindow.cpp
@@ -7,6 +7,10 @@
 #include "pet/surface/PetContextMenu.h"
 #include "pet/surface/PropSurfaceWindow.h"
 
+#ifdef Q_OS_MACOS
+#include "platform/MacPetWindowBehavior.h"
+#endif
+
 #include <QContextMenuEvent>
 #include <QImage>
 #include <QLabel>
@@ -121,7 +125,8 @@ void PetSurfaceWindow::contextMenuEvent(QContextMenuEvent *event)
         return;
     }
 
-    showContextMenuAt(event->globalPos());
+    event->accept();
+    showContextMenuQueued(event->globalPos());
 }
 
 void PetSurfaceWindow::mousePressEvent(QMouseEvent *event)
@@ -132,7 +137,8 @@ void PetSurfaceWindow::mousePressEvent(QMouseEvent *event)
     }
 
     if (event->button() == Qt::RightButton) {
-        showContextMenuAt(event->globalPosition().toPoint());
+        event->accept();
+        showContextMenuQueued(event->globalPosition().toPoint());
         return;
     }
 
@@ -382,7 +388,27 @@ QRegion PetSurfaceWindow::regionFromCurrentFrame() const
 
 void PetSurfaceWindow::showContextMenuAt(const QPoint &globalPosition)
 {
+#ifdef Q_OS_MACOS
+    prepareMacPetWindowForContextMenu(windowHandle());
+#endif
     PetContextMenu::show(this, m_runtime, m_eventBridge, m_shellController, m_chatController, globalPosition);
+}
+
+void PetSurfaceWindow::showContextMenuQueued(const QPoint &globalPosition)
+{
+    m_pendingContextMenuPosition = globalPosition;
+    if (m_contextMenuPending) {
+        return;
+    }
+
+    m_contextMenuPending = true;
+    QTimer::singleShot(0, this, [this]() {
+        m_contextMenuPending = false;
+        if (!m_runtime->pointerInteractionEnabled()) {
+            return;
+        }
+        showContextMenuAt(m_pendingContextMenuPosition);
+    });
 }
 
 void PetSurfaceWindow::playSoundFromRuntime()

--- a/apps/desktop/src/pet/surface/PetSurfaceWindow.h
+++ b/apps/desktop/src/pet/surface/PetSurfaceWindow.h
@@ -55,6 +55,7 @@ private:
     void submitIdleLoopFinishedIfStillCurrent(int playbackSerial);
     void applyCurrentFrameMask();
     QRegion regionFromCurrentFrame() const;
+    void showContextMenuQueued(const QPoint &globalPosition);
     void showContextMenuAt(const QPoint &globalPosition);
     void playSoundFromRuntime();
     void showPropFromRuntime();
@@ -72,6 +73,8 @@ private:
     QTimer m_propExpireTimer;
     QPoint m_pressPosition;
     QPoint m_pendingSingleClickPosition;
+    QPoint m_pendingContextMenuPosition;
     bool m_dragMoved = false;
     bool m_doubleClickPending = false;
+    bool m_contextMenuPending = false;
 };

--- a/apps/desktop/src/platform/MacPetWindowBehavior.h
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.h
@@ -18,6 +18,10 @@ void applyMacPetWindowBaseBehavior(QWindow *window);
 // “固定在屏幕最上层”的实验模式，不适合这个需要可随时取消的普通开关。
 void setMacPetWindowAlwaysOnTop(QWindow *window, bool alwaysOnTop);
 
+// 右键菜单显示前调用：确保 accessory app 和跨 Space 桌宠窗口在当前
+// Space 成为可接收菜单的前台上下文。
+void prepareMacPetWindowForContextMenu(QWindow *window);
+
 // 聊天窗口是普通工作窗口，打开时应让应用显示在 Dock；关闭后恢复桌宠
 // 辅助应用模式，避免只剩桌宠本体时占用普通应用位置。
 void setMacApplicationDockVisible(bool visible);

--- a/apps/desktop/src/platform/MacPetWindowBehavior.mm
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.mm
@@ -90,6 +90,17 @@ void setMacPetWindowAlwaysOnTop(QWindow *window, bool alwaysOnTop)
     // 这样用户手滑点错时，桌宠仍停在原地，后续自然可以被其他窗口覆盖。
 }
 
+void prepareMacPetWindowForContextMenu(QWindow *window)
+{
+    NSWindow *nativeWindow = nativeWindowForQWindow(window);
+    if (nativeWindow == nil) {
+        return;
+    }
+
+    [nativeWindow orderFrontRegardless];
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
 void setMacApplicationDockVisible(bool visible)
 {
     [NSApp setActivationPolicy:visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -226,5 +226,75 @@ int main(int argc, char *argv[])
         // Full pacer drain timing is covered by ChatTextPacerSmoke.
     }
 
+    // --- Phase 2.3.1: mid-stream expression switch (STREAMING -> GATED -> STREAMING) ---
+    {
+        PetRuntime gRuntime;
+        for (int i = 0; i < 5 && gRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            gRuntime.handleAnimationFinished();
+        }
+        require(gRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "mid-stream gate test should start from idle runtime state");
+
+        ChatController gController(&gRuntime, &settings);
+
+        ChatStreamEvent gStarted;
+        gStarted.type = QStringLiteral("RUN_STARTED");
+        gController.applyStreamEvent(gStarted);
+
+        ChatStreamEvent gExpr1;
+        gExpr1.type = QStringLiteral("CUSTOM");
+        gExpr1.name = QStringLiteral("miles.pet.expression.requested");
+        gExpr1.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        gExpr1.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        gController.applyStreamEvent(gExpr1);
+        require(gRuntime.currentState() == QStringLiteral("speaking"),
+                "initial expression should apply after the synchronous clean finish boundary");
+
+        ChatStreamEvent gStart;
+        gStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        gStart.role = QStringLiteral("assistant");
+        gController.applyStreamEvent(gStart);
+
+        ChatStreamEvent gText1;
+        gText1.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        gText1.delta = QStringLiteral("片段1");
+        gController.applyStreamEvent(gText1);
+        require(waitFor([&gController]() {
+                    return gController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("片段1");
+                }),
+                "STREAMING text should drain through the pacer before the mid-run gate");
+
+        ChatStreamEvent gExpr2;
+        gExpr2.type = QStringLiteral("CUSTOM");
+        gExpr2.name = QStringLiteral("miles.pet.expression.requested");
+        gExpr2.value.insert(QStringLiteral("state"), QStringLiteral("thinking"));
+        gExpr2.value.insert(QStringLiteral("expression"), QStringLiteral("neutral"));
+        gController.applyStreamEvent(gExpr2);
+
+        ChatStreamEvent gText2;
+        gText2.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        gText2.delta = QStringLiteral("片段2");
+        gController.applyStreamEvent(gText2);
+
+        const QString preBoundaryText = gController.messages().constLast()
+                .toMap().value(QStringLiteral("text")).toString();
+        require(preBoundaryText == QStringLiteral("片段1"),
+                "GATED text should stay buffered before the animation boundary");
+        require(gRuntime.currentState() == QStringLiteral("speaking"),
+                "mid-run expression should not apply before the animation boundary");
+
+        gRuntime.handleAnimationFinished();
+        require(gRuntime.currentState() == QStringLiteral("thinking"),
+                "boundary callback should request the queued thinking expression");
+        require(gRuntime.currentActionId() == QStringLiteral("thinking"),
+                "queued thinking expression should switch to the thinking action at the boundary");
+        require(waitFor([&gController]() {
+                    return gController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("片段1片段2");
+                }),
+                "GATED text should drain through the pacer after the boundary callback");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -296,5 +296,67 @@ int main(int argc, char *argv[])
                 "GATED text should drain through the pacer after the boundary callback");
     }
 
+    // --- Phase 2.3.1 Task 7: RUN_FINISHED waits for animation boundary before idle ---
+    {
+        PetRuntime fRuntime;
+        for (int i = 0; i < 5 && fRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            fRuntime.handleAnimationFinished();
+        }
+        require(fRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "RUN_FINISHED boundary test should start from idle runtime state");
+
+        ChatController fController(&fRuntime, &settings);
+
+        ChatStreamEvent fStarted;
+        fStarted.type = QStringLiteral("RUN_STARTED");
+        fController.applyStreamEvent(fStarted);
+
+        ChatStreamEvent fExpr;
+        fExpr.type = QStringLiteral("CUSTOM");
+        fExpr.name = QStringLiteral("miles.pet.expression.requested");
+        fExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        fExpr.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        fController.applyStreamEvent(fExpr);
+        require(fRuntime.currentState() == QStringLiteral("speaking"),
+                "RUN_FINISHED boundary test should enter speaking before finish");
+        const QString fSpeakingAction = fRuntime.currentActionId();
+
+        ChatStreamEvent fStart;
+        fStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        fStart.role = QStringLiteral("assistant");
+        fController.applyStreamEvent(fStart);
+
+        ChatStreamEvent fText;
+        fText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        fText.delta = QStringLiteral("结尾");
+        fController.applyStreamEvent(fText);
+        require(waitFor([&fController]() {
+                    return fController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("结尾");
+                }),
+                "RUN_FINISHED boundary test should stream text before finish");
+
+        ChatStreamEvent fFinished;
+        fFinished.type = QStringLiteral("RUN_FINISHED");
+        fFinished.runId = QStringLiteral("mock-run-finished");
+        fController.applyStreamEvent(fFinished);
+
+        require(!fController.sending(), "RUN_FINISHED should clear sending while waiting for boundary");
+        require(fController.statusText() == QStringLiteral("未连接"),
+                "RUN_FINISHED should restore non-sending status while waiting for boundary");
+        require(!fController.messages().constLast().toMap().value(QStringLiteral("pending")).toBool(),
+                "RUN_FINISHED should clear assistant pending before boundary");
+        require(fRuntime.currentState() == QStringLiteral("speaking"),
+                "RUN_FINISHED must not synchronously return to idle");
+        require(fRuntime.currentActionId() == fSpeakingAction,
+                "RUN_FINISHED must not synchronously replace the current animation");
+
+        fRuntime.handleAnimationFinished();
+        require(fRuntime.currentState() == QStringLiteral("idle"),
+                "RUN_FINISHED should return to idle only after boundary callback");
+        require(fRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "RUN_FINISHED boundary callback should restore idle action");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -358,5 +358,80 @@ int main(int argc, char *argv[])
                 "RUN_FINISHED boundary callback should restore idle action");
     }
 
+    // --- Phase 2.3.1 Task 8: cancel during GATED drains buffered text and idles ---
+    {
+        PetRuntime cRuntime;
+        for (int i = 0; i < 5 && cRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            cRuntime.handleAnimationFinished();
+        }
+        require(cRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "GATED cancel test should start from idle runtime state");
+
+        ChatController cController(&cRuntime, &settings);
+
+        ChatStreamEvent cStarted;
+        cStarted.type = QStringLiteral("RUN_STARTED");
+        cController.applyStreamEvent(cStarted);
+
+        ChatStreamEvent cExpr1;
+        cExpr1.type = QStringLiteral("CUSTOM");
+        cExpr1.name = QStringLiteral("miles.pet.expression.requested");
+        cExpr1.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        cExpr1.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        cController.applyStreamEvent(cExpr1);
+        require(cRuntime.currentState() == QStringLiteral("speaking"),
+                "GATED cancel test should enter speaking before cancel");
+
+        ChatStreamEvent cStart;
+        cStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        cStart.role = QStringLiteral("assistant");
+        cController.applyStreamEvent(cStart);
+
+        ChatStreamEvent cText1;
+        cText1.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        cText1.delta = QStringLiteral("前");
+        cController.applyStreamEvent(cText1);
+        require(waitFor([&cController]() {
+                    return cController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("前");
+                }),
+                "GATED cancel test should stream the first segment before the gate");
+
+        ChatStreamEvent cExpr2;
+        cExpr2.type = QStringLiteral("CUSTOM");
+        cExpr2.name = QStringLiteral("miles.pet.expression.requested");
+        cExpr2.value.insert(QStringLiteral("state"), QStringLiteral("thinking"));
+        cExpr2.value.insert(QStringLiteral("expression"), QStringLiteral("neutral"));
+        cController.applyStreamEvent(cExpr2);
+
+        ChatStreamEvent cText2;
+        cText2.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        cText2.delta = QStringLiteral("后");
+        cController.applyStreamEvent(cText2);
+        require(cController.messages().constLast().toMap()
+                    .value(QStringLiteral("text")).toString() == QStringLiteral("前"),
+                "GATED cancel test should hold text before cancel");
+
+        const int messagesBeforeGatedCancel = cController.messages().size();
+        cController.cancelCurrentReply();
+        require(!cController.sending(), "cancel during GATED should clear sending");
+        require(cRuntime.currentState() == QStringLiteral("idle"),
+                "cancel during GATED should return runtime to idle");
+        require(cRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "cancel during GATED should restore idle action");
+        require(waitFor([&cController]() {
+                    return cController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("前后");
+                }),
+                "cancel during GATED should drain held text through the pacer");
+
+        ChatStreamEvent cStray;
+        cStray.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        cStray.delta = QStringLiteral("残留");
+        cController.applyStreamEvent(cStray);
+        require(cController.messages().size() == messagesBeforeGatedCancel,
+                "stream content after GATED cancel must not append a new assistant message");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -553,5 +553,41 @@ int main(int argc, char *argv[])
                 "stale pacer chunks must not leak into the next assistant message");
     }
 
+    // --- Phase 2.3.1: sendMessage must invalidate stale pacer chunks before RUN_STARTED ---
+    {
+        PetRuntime sRuntime;
+        for (int i = 0; i < 5 && sRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            sRuntime.handleAnimationFinished();
+        }
+
+        ChatController sController(&sRuntime, &settings);
+
+        ChatStreamEvent firstStarted;
+        firstStarted.type = QStringLiteral("RUN_STARTED");
+        sController.applyStreamEvent(firstStarted);
+
+        ChatStreamEvent firstStart;
+        firstStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        firstStart.role = QStringLiteral("assistant");
+        sController.applyStreamEvent(firstStart);
+
+        ChatStreamEvent firstText;
+        firstText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        firstText.delta = QStringLiteral("旧旧旧旧旧旧旧旧旧旧");
+        sController.applyStreamEvent(firstText);
+
+        ChatStreamEvent firstFinished;
+        firstFinished.type = QStringLiteral("RUN_FINISHED");
+        sController.applyStreamEvent(firstFinished);
+        sRuntime.handleAnimationFinished();
+
+        sController.sendMessage(QStringLiteral("next"));
+        waitFor([]() { return false; }, 200);
+
+        const auto messages = sController.messages();
+        require(!messages.constLast().toMap().value(QStringLiteral("text")).toString().contains(QStringLiteral("旧")),
+                "sendMessage should invalidate stale pacer chunks before sidecar RUN_STARTED arrives");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -502,5 +502,56 @@ int main(int argc, char *argv[])
                 "RUN_ERROR during GATED should mark the assistant message as error");
     }
 
+    // --- Phase 2.3.1: old pacer chunks must not leak into a later reply ---
+    {
+        PetRuntime lRuntime;
+        for (int i = 0; i < 5 && lRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            lRuntime.handleAnimationFinished();
+        }
+
+        ChatController lController(&lRuntime, &settings);
+
+        ChatStreamEvent firstStarted;
+        firstStarted.type = QStringLiteral("RUN_STARTED");
+        lController.applyStreamEvent(firstStarted);
+
+        ChatStreamEvent firstStart;
+        firstStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        firstStart.role = QStringLiteral("assistant");
+        lController.applyStreamEvent(firstStart);
+
+        ChatStreamEvent firstText;
+        firstText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        firstText.delta = QStringLiteral("旧旧旧旧旧旧旧旧旧旧");
+        lController.applyStreamEvent(firstText);
+
+        ChatStreamEvent firstFinished;
+        firstFinished.type = QStringLiteral("RUN_FINISHED");
+        lController.applyStreamEvent(firstFinished);
+        lRuntime.handleAnimationFinished();
+        const int messagesAfterFirst = lController.messages().size();
+
+        ChatStreamEvent secondStarted;
+        secondStarted.type = QStringLiteral("RUN_STARTED");
+        lController.applyStreamEvent(secondStarted);
+
+        ChatStreamEvent secondStart;
+        secondStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        secondStart.role = QStringLiteral("assistant");
+        lController.applyStreamEvent(secondStart);
+
+        const int messagesAfterSecondStart = lController.messages().size();
+        require(messagesAfterSecondStart == messagesAfterFirst + 1,
+                "second reply setup should append one assistant message");
+
+        waitFor([]() { return false; }, 200);
+
+        const auto messages = lController.messages();
+        require(messages.size() == messagesAfterSecondStart,
+                "stale pacer chunks must not create ghost messages after a new reply starts");
+        require(messages.constLast().toMap().value(QStringLiteral("text")).toString().isEmpty(),
+                "stale pacer chunks must not leak into the next assistant message");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -433,5 +433,74 @@ int main(int argc, char *argv[])
                 "stream content after GATED cancel must not append a new assistant message");
     }
 
+    // --- Phase 2.3.1 Task 8: RUN_ERROR during GATED drains buffered text without ghost messages ---
+    {
+        PetRuntime eRuntime;
+        for (int i = 0; i < 5 && eRuntime.currentActionId() != QStringLiteral("idle_stand"); ++i) {
+            eRuntime.handleAnimationFinished();
+        }
+        require(eRuntime.currentActionId() == QStringLiteral("idle_stand"),
+                "GATED error test should start from idle runtime state");
+
+        ChatController eController(&eRuntime, &settings);
+
+        ChatStreamEvent eStarted;
+        eStarted.type = QStringLiteral("RUN_STARTED");
+        eController.applyStreamEvent(eStarted);
+
+        ChatStreamEvent eExpr1;
+        eExpr1.type = QStringLiteral("CUSTOM");
+        eExpr1.name = QStringLiteral("miles.pet.expression.requested");
+        eExpr1.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        eExpr1.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        eController.applyStreamEvent(eExpr1);
+
+        ChatStreamEvent eStart;
+        eStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        eStart.role = QStringLiteral("assistant");
+        eController.applyStreamEvent(eStart);
+
+        ChatStreamEvent eText1;
+        eText1.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        eText1.delta = QStringLiteral("前");
+        eController.applyStreamEvent(eText1);
+        require(waitFor([&eController]() {
+                    return eController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("前");
+                }),
+                "GATED error test should stream the first segment before the gate");
+
+        ChatStreamEvent eExpr2;
+        eExpr2.type = QStringLiteral("CUSTOM");
+        eExpr2.name = QStringLiteral("miles.pet.expression.requested");
+        eExpr2.value.insert(QStringLiteral("state"), QStringLiteral("thinking"));
+        eExpr2.value.insert(QStringLiteral("expression"), QStringLiteral("neutral"));
+        eController.applyStreamEvent(eExpr2);
+
+        ChatStreamEvent eText2;
+        eText2.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        eText2.delta = QStringLiteral("后");
+        eController.applyStreamEvent(eText2);
+        const int messagesBeforeError = eController.messages().size();
+
+        ChatStreamEvent eError;
+        eError.type = QStringLiteral("RUN_ERROR");
+        eError.error = QStringLiteral("mock failure");
+        eController.applyStreamEvent(eError);
+
+        require(!eController.sending(), "RUN_ERROR during GATED should clear sending");
+        require(eRuntime.currentState() == QStringLiteral("error"),
+                "RUN_ERROR during GATED should move pet to error state");
+        require(waitFor([&eController]() {
+                    return eController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("前后");
+                }),
+                "RUN_ERROR during GATED should drain held text through the pacer");
+        require(eController.messages().size() == messagesBeforeError,
+                "RUN_ERROR during GATED must not create a ghost assistant message");
+        require(eController.messages().constLast().toMap().value(QStringLiteral("error")).toBool(),
+                "RUN_ERROR during GATED should mark the assistant message as error");
+    }
+
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -5,7 +5,11 @@
 #include "settings/SettingsService.h"
 
 #include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QThread>
 
+#include <functional>
 #include <stdexcept>
 
 namespace {
@@ -14,6 +18,21 @@ void require(bool condition, const char *message)
     if (!condition) {
         throw std::runtime_error(message);
     }
+}
+
+bool waitFor(const std::function<bool()> &predicate, int timeoutMs = 1500)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < timeoutMs) {
+        if (predicate()) {
+            return true;
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        QThread::msleep(5);
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return predicate();
 }
 } // namespace
 
@@ -26,6 +45,7 @@ int main(int argc, char *argv[])
     settings.setModel(QStringLiteral("miles-test-model"));
     settings.setTemperature(0.2);
     settings.setMaxTokens(128);
+    settings.setMsPerChar(40);
 
     PetRuntime runtime;
     ChatController controller(&runtime, &settings);
@@ -42,6 +62,7 @@ int main(int argc, char *argv[])
     thinkingEvent.value.insert(QStringLiteral("state"), QStringLiteral("thinking"));
     thinkingEvent.value.insert(QStringLiteral("expression"), QStringLiteral("neutral"));
     controller.applyStreamEvent(thinkingEvent);
+    runtime.handleAnimationFinished();
     require(runtime.currentState() == QStringLiteral("thinking"), "custom thinking event should update runtime state");
     require(runtime.currentActionId() == QStringLiteral("thinking"), "thinking neutral should play thinking action");
 
@@ -57,8 +78,11 @@ int main(int argc, char *argv[])
     messageContent.messageId = QStringLiteral("assistant-1");
     messageContent.delta = QStringLiteral("异议");
     controller.applyStreamEvent(messageContent);
-    require(controller.messages().constFirst().toMap().value("text").toString() == QStringLiteral("异议"),
-            "content delta should append to assistant message");
+    require(waitFor([&controller]() {
+                return controller.messages().constFirst().toMap().value("text").toString()
+                    == QStringLiteral("异议");
+            }),
+            "content delta should append to assistant message through the pacer");
 
     ChatStreamEvent expressionEvent;
     expressionEvent.type = QStringLiteral("CUSTOM");
@@ -66,6 +90,10 @@ int main(int argc, char *argv[])
     expressionEvent.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
     expressionEvent.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
     controller.applyStreamEvent(expressionEvent);
+    require(waitFor([&runtime]() {
+                return runtime.currentState() == QStringLiteral("speaking");
+            }),
+            "custom expression event should update runtime state after the gate opens");
     require(runtime.currentState() == QStringLiteral("speaking"), "custom expression event should update runtime state");
     require(runtime.currentActionId() == QStringLiteral("objecting")
                 || runtime.currentActionId() == QStringLiteral("crossed"),
@@ -115,9 +143,10 @@ int main(int argc, char *argv[])
     require(controller.messages().size() == messagesBeforeCancel,
             "stream content after cancel must not append a new assistant message");
 
-    // Hold buffer round-trip: feed a delta while the controller is in its default
-    // "immediate flush" mode (Phase 2.1 plumbing -- full GATED logic lands in 2.3).
+    // Hold buffer round-trip: feed deltas while the controller is waiting for
+    // cleanFinishReady, then let the pacer drain after the animation boundary.
     PetRuntime hbRuntime;
+    hbRuntime.setState(QStringLiteral("speaking"));
     ChatController hbController(&hbRuntime, &settings);
 
     ChatStreamEvent hbStarted;
@@ -135,14 +164,67 @@ int main(int argc, char *argv[])
     hbController.applyStreamEvent(hbContent);
 
     require(hbController.messages().constFirst().toMap().value("text").toString()
-                == QStringLiteral("片段一"),
-            "hold buffer should flush content immediately in phase 2.1");
+                .isEmpty(),
+            "hold buffer should not flush content before cleanFinishReady");
+    hbRuntime.handleAnimationFinished();
+    require(waitFor([&hbController]() {
+                return hbController.messages().constFirst().toMap().value("text").toString()
+                    == QStringLiteral("片段一");
+            }),
+            "hold buffer should drain through the pacer after cleanFinishReady");
 
     hbContent.delta = QStringLiteral("片段二");
     hbController.applyStreamEvent(hbContent);
-    require(hbController.messages().constFirst().toMap().value("text").toString()
-                == QStringLiteral("片段一片段二"),
-            "subsequent deltas should append through the hold buffer");
+    require(waitFor([&hbController]() {
+                return hbController.messages().constFirst().toMap().value("text").toString()
+                    == QStringLiteral("片段一片段二");
+            }),
+            "subsequent deltas should append through the pacer");
+
+    // --- Phase 2.3.1: BUFFERING_FOR_START holds text until cleanFinishReady ---
+    {
+        PetRuntime smRuntime;
+        smRuntime.setState(QStringLiteral("speaking")); // simulate non-idle baseline
+        ChatController smController(&smRuntime, &settings);
+
+        ChatStreamEvent smStarted;
+        smStarted.type = QStringLiteral("RUN_STARTED");
+        smController.applyStreamEvent(smStarted);
+        // BUFFERING_FOR_START: text must be queued, not emitted to UI yet.
+
+        ChatStreamEvent smExpr;
+        smExpr.type = QStringLiteral("CUSTOM");
+        smExpr.name = QStringLiteral("miles.pet.expression.requested");
+        smExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        smExpr.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        smController.applyStreamEvent(smExpr);
+
+        ChatStreamEvent smStart;
+        smStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        smStart.role = QStringLiteral("assistant");
+        smController.applyStreamEvent(smStart);
+
+        ChatStreamEvent smText;
+        smText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        smText.delta = QStringLiteral("异议!");
+        smController.applyStreamEvent(smText);
+
+        const auto messagesWhileBuffering = smController.messages();
+        const QString textWhileBuffering = messagesWhileBuffering.constLast()
+                .toMap().value(QStringLiteral("text")).toString();
+        require(textWhileBuffering.isEmpty(),
+                "BUFFERING_FOR_START must NOT push streamed text to the UI yet");
+
+        // Simulate PetRuntime reaching a clean finish on the previous animation.
+        smRuntime.handleAnimationFinished();
+        require(waitFor([&smController]() {
+                    const auto messages = smController.messages();
+                    return !messages.isEmpty()
+                        && messages.constLast().toMap().value(QStringLiteral("text")).toString().startsWith(QStringLiteral("异"));
+                }),
+                "cleanFinishReady should let buffered text start draining through the pacer");
+        // Full pacer drain timing is covered by ChatTextPacerSmoke.
+    }
 
     return 0;
 }

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -226,6 +226,55 @@ int main(int argc, char *argv[])
         // Full pacer drain timing is covered by ChatTextPacerSmoke.
     }
 
+    // --- Fast response: RUN_FINISHED must not discard the start expression while buffering ---
+    {
+        PetRuntime fastRuntime;
+        fastRuntime.setState(QStringLiteral("thinking"));
+        ChatController fastController(&fastRuntime, &settings);
+
+        ChatStreamEvent fastStarted;
+        fastStarted.type = QStringLiteral("RUN_STARTED");
+        fastController.applyStreamEvent(fastStarted);
+
+        ChatStreamEvent fastExpr;
+        fastExpr.type = QStringLiteral("CUSTOM");
+        fastExpr.name = QStringLiteral("miles.pet.expression.requested");
+        fastExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        fastExpr.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        fastController.applyStreamEvent(fastExpr);
+
+        ChatStreamEvent fastStart;
+        fastStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        fastStart.role = QStringLiteral("assistant");
+        fastController.applyStreamEvent(fastStart);
+
+        ChatStreamEvent fastText;
+        fastText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        fastText.delta = QStringLiteral("快速异议");
+        fastController.applyStreamEvent(fastText);
+
+        ChatStreamEvent fastEnd;
+        fastEnd.type = QStringLiteral("TEXT_MESSAGE_END");
+        fastController.applyStreamEvent(fastEnd);
+
+        ChatStreamEvent fastFinished;
+        fastFinished.type = QStringLiteral("RUN_FINISHED");
+        fastController.applyStreamEvent(fastFinished);
+
+        require(fastRuntime.currentActionId() != QStringLiteral("objecting"),
+                "fast response should still wait for clean finish before applying start expression");
+
+        fastRuntime.handleAnimationFinished();
+        require(fastRuntime.currentActionId() == QStringLiteral("objecting")
+                    || fastRuntime.currentActionId() == QStringLiteral("crossed"),
+                "RUN_FINISHED during BUFFERING_FOR_START must preserve and apply the pending objection expression");
+        require(waitFor([&fastController]() {
+                    return fastController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString() == QStringLiteral("快速异议");
+                }),
+                "fast buffered text should drain after the preserved start expression applies");
+    }
+
     // --- Phase 2.3.1: mid-stream expression switch (STREAMING -> GATED -> STREAMING) ---
     {
         PetRuntime gRuntime;

--- a/apps/desktop/tests/chat_controller_smoke.cpp
+++ b/apps/desktop/tests/chat_controller_smoke.cpp
@@ -587,6 +587,20 @@ int main(int argc, char *argv[])
         const auto messages = sController.messages();
         require(!messages.constLast().toMap().value(QStringLiteral("text")).toString().contains(QStringLiteral("旧")),
                 "sendMessage should invalidate stale pacer chunks before sidecar RUN_STARTED arrives");
+
+        ChatStreamEvent nextStarted;
+        nextStarted.type = QStringLiteral("RUN_STARTED");
+        sController.applyStreamEvent(nextStarted);
+        sRuntime.handleAnimationFinished();
+        ChatStreamEvent nextText;
+        nextText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        nextText.delta = QStringLiteral("新");
+        sController.applyStreamEvent(nextText);
+        require(waitFor([&sController]() {
+                    return sController.messages().constLast().toMap()
+                        .value(QStringLiteral("text")).toString().contains(QStringLiteral("新"));
+                }, 500),
+                "new reply text should not wait for stale pacer chunks to drain");
     }
 
     return 0;

--- a/apps/desktop/tests/chat_text_pacer_smoke.cpp
+++ b/apps/desktop/tests/chat_text_pacer_smoke.cpp
@@ -1,0 +1,74 @@
+#include "chat/ChatTextPacer.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QSignalSpy>
+#include <QString>
+#include <QTimer>
+#include <QVariant>
+
+#include <cassert>
+
+namespace {
+
+template <typename Predicate>
+bool waitFor(QCoreApplication &app, int timeoutMs, Predicate predicate)
+{
+    QTimer deadline;
+    deadline.setSingleShot(true);
+    deadline.start(timeoutMs);
+    while (!predicate() && deadline.isActive()) {
+        app.processEvents(QEventLoop::AllEvents, 5);
+    }
+    return predicate();
+}
+
+QString assembleChunks(const QSignalSpy &chunks)
+{
+    QString assembled;
+    for (const QList<QVariant> &args : chunks) {
+        assembled.append(args.at(0).toString());
+    }
+    return assembled;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(20);
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+
+        pacer.append(QStringLiteral("abc"));
+        assert(pacer.pendingCount() == 3);
+
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+        assert(assembleChunks(chunks) == QStringLiteral("abc"));
+    }
+
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(15);
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+
+        pacer.append(QStringLiteral("异议"));
+
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+        assert(assembleChunks(chunks) == QStringLiteral("异议"));
+        assert(chunks.size() == 2);
+    }
+
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(120);
+        assert(pacer.msPerChar() == 120);
+    }
+
+    return 0;
+}

--- a/apps/desktop/tests/chat_text_pacer_smoke.cpp
+++ b/apps/desktop/tests/chat_text_pacer_smoke.cpp
@@ -1,13 +1,14 @@
 #include "chat/ChatTextPacer.h"
 
 #include <QCoreApplication>
+#include <QDateTime>
 #include <QEventLoop>
 #include <QSignalSpy>
 #include <QString>
 #include <QTimer>
 #include <QVariant>
 
-#include <cassert>
+#include <stdexcept>
 
 namespace {
 
@@ -32,6 +33,13 @@ QString assembleChunks(const QSignalSpy &chunks)
     return assembled;
 }
 
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
 } // namespace
 
 int main(int argc, char *argv[])
@@ -44,11 +52,11 @@ int main(int argc, char *argv[])
         QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
 
         pacer.append(QStringLiteral("abc"));
-        assert(pacer.pendingCount() == 3);
+        require(pacer.pendingCount() == 3, "pacer should queue all appended characters");
 
         const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
-        assert(drained);
-        assert(assembleChunks(chunks) == QStringLiteral("abc"));
+        require(drained, "basic stream should drain");
+        require(assembleChunks(chunks) == QStringLiteral("abc"), "basic stream should emit all chunks in order");
     }
 
     {
@@ -59,15 +67,49 @@ int main(int argc, char *argv[])
         pacer.append(QStringLiteral("异议"));
 
         const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
-        assert(drained);
-        assert(assembleChunks(chunks) == QStringLiteral("异议"));
-        assert(chunks.size() == 2);
+        require(drained, "CJK stream should drain");
+        require(assembleChunks(chunks) == QStringLiteral("异议"), "CJK stream should emit all chunks in order");
+        require(chunks.size() == 2, "CJK stream should emit one chunk per character");
     }
 
     {
         ChatTextPacer pacer;
         pacer.setMsPerChar(120);
-        assert(pacer.msPerChar() == 120);
+        require(pacer.msPerChar() == 120, "msPerChar getter should reflect setter value");
+    }
+
+    // --- Backlog catch-up: when queue exceeds maxBacklog, interval halves ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(40);
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+
+        // 60 chars > maxBacklog (30), so the effective interval should drop.
+        QString longPayload;
+        for (int i = 0; i < 60; ++i) {
+            longPayload.append(QChar('x'));
+        }
+
+        const qint64 start = QDateTime::currentMSecsSinceEpoch();
+        pacer.append(longPayload);
+
+        const bool drained = waitFor(app, 3000, [&]() { return pacer.pendingCount() == 0; });
+        require(drained, "backlog stream should drain");
+        const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - start;
+
+        require(elapsed < 2200, "backlog catch-up should drain faster than the no-speedup baseline");
+        require(chunks.size() == 60, "backlog stream should emit every character");
+    }
+
+    // --- setMsPerChar updates an active timer interval ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(200);
+        pacer.append(QStringLiteral("yz"));
+        pacer.setMsPerChar(15);
+
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        require(drained, "active timer should adopt updated msPerChar interval");
     }
 
     return 0;

--- a/apps/desktop/tests/logging_formatter_smoke.cpp
+++ b/apps/desktop/tests/logging_formatter_smoke.cpp
@@ -1,0 +1,58 @@
+#include "logging/MilesLogHandler.h"
+
+#include <QCoreApplication>
+#include <QMessageLogContext>
+#include <QString>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    require(MilesLogHandler::isMilesCategory("miles.chat"),
+            "miles.chat should be treated as project category");
+    require(!MilesLogHandler::isMilesCategory("qt.qml.binding"),
+            "qt.qml.binding should not be treated as project category");
+
+    QMessageLogContext context("ChatController.cpp", 302, "sendMessage", "miles.chat");
+    const QString consoleLine = MilesLogHandler::formatMilesMessage(
+        QtInfoMsg,
+        context,
+        QStringLiteral("send chat request messageLen=12"),
+        false);
+    require(consoleLine.contains(QStringLiteral("INFO  [MILES.CHAT]")),
+            "console line should contain padded INFO level and upper category");
+    require(consoleLine.contains(QStringLiteral("send chat request messageLen=12")),
+            "console line should contain message");
+    require(consoleLine.endsWith(QStringLiteral("[ChatController.cpp:302]")),
+            "console line should end with source");
+    require(!consoleLine.left(10).contains('-'),
+            "console line should omit date");
+
+    const QString fileLine = MilesLogHandler::formatMilesMessage(
+        QtDebugMsg,
+        context,
+        QStringLiteral("stream event type=CUSTOM"),
+        true);
+    require(fileLine.contains(QStringLiteral("DEBUG [MILES.CHAT]")),
+            "file line should contain DEBUG level and category");
+    require(fileLine.left(10).contains('-'),
+            "file line should include date");
+
+    std::cout << "logging formatter smoke checks passed.\n";
+    return 0;
+}

--- a/apps/desktop/tests/logging_formatter_smoke.cpp
+++ b/apps/desktop/tests/logging_formatter_smoke.cpp
@@ -1,13 +1,22 @@
 #include "logging/MilesLogHandler.h"
 
 #include <QCoreApplication>
+#include <QFile>
+#include <QLoggingCategory>
 #include <QMessageLogContext>
 #include <QString>
+#include <QTemporaryDir>
+#include <QTextStream>
 
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
 
 namespace {
+
+Q_LOGGING_CATEGORY(smokeLog, "miles.chat", QtInfoMsg)
 
 void require(bool condition, const char *message)
 {
@@ -15,6 +24,23 @@ void require(bool condition, const char *message)
         std::cerr << message << '\n';
         std::exit(1);
     }
+}
+
+QString readFile(const QString &path)
+{
+    QFile file(path);
+    require(file.open(QIODevice::ReadOnly | QIODevice::Text),
+            "smoke log file should be readable");
+    return QString::fromUtf8(file.readAll());
+}
+
+void appendSentinel(const QString &path)
+{
+    QFile file(path);
+    require(file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text),
+            "smoke log file should be appendable");
+    QTextStream stream(&file);
+    stream << "SIDEcar_APPEND_SENTINEL\n";
 }
 
 } // namespace
@@ -52,6 +78,39 @@ int main(int argc, char *argv[])
             "file line should contain DEBUG level and category");
     require(fileLine.left(10).contains('-'),
             "file line should include date");
+
+    QTemporaryDir tempDir;
+    require(tempDir.isValid(), "temporary directory should be valid");
+    const QString logPath = tempDir.filePath(QStringLiteral("miles-smoke.log"));
+    qputenv("MILES_LOG_FILE", logPath.toLocal8Bit());
+
+    MilesLogHandler::install();
+    MilesLogHandler::install();
+
+    qCInfo(smokeLog) << "first smoke line";
+    appendSentinel(logPath);
+    qCInfo(smokeLog) << "second smoke line";
+
+    const QString logContent = readFile(logPath);
+    require(logContent.contains(QStringLiteral("first smoke line")),
+            "file log should contain first Qt line");
+    require(logContent.contains(QStringLiteral("SIDEcar_APPEND_SENTINEL")),
+            "file log should preserve external append sentinel");
+    require(logContent.contains(QStringLiteral("second smoke line")),
+            "file log should contain later Qt line");
+
+    std::atomic_bool nonMilesReturned = false;
+    std::thread nonMilesThread([&nonMilesReturned]() {
+        qInfo("non miles smoke line");
+        nonMilesReturned.store(true);
+    });
+    nonMilesThread.detach();
+
+    for (int i = 0; i < 50 && !nonMilesReturned.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    require(nonMilesReturned.load(),
+            "non-miles log after double install should not recurse or deadlock");
 
     std::cout << "logging formatter smoke checks passed.\n";
     return 0;

--- a/apps/desktop/tests/pet_runtime_smoke.cpp
+++ b/apps/desktop/tests/pet_runtime_smoke.cpp
@@ -648,13 +648,15 @@ int main(int argc, char *argv[])
     runtime.setAudioLanguage("jp");
     runtime.submitExpressionRequest("speaking", "objection", 0.0);
     require(runtime.currentActionId() == "objecting", "speaking + objection 应映射到异议动作");
+    runtime.submitExpressionRequest("speaking", "neutral", 0.0);
+    require(runtime.currentActionId() == "crossed", "speaking + neutral 应映射到可见说话动作，而不是站立待机");
     runtime.submitExpressionRequest("idle", "polite", 0.0);
     require(runtime.currentActionId() == "bow", "idle + polite 应映射到鞠躬动作");
     runtime.submitExpressionRequest("speaking", "unknown-expression", 0.0);
-    require(runtime.currentActionId() == "idle_stand", "未知 expression 应降级到 neutral 映射");
+    require(runtime.currentActionId() == "crossed", "未知 expression 应降级到 speaking neutral 的可见说话动作");
     runtime.playAction("bow");
     runtime.submitExpressionRequest("unknown-state", "neutral", 0.0);
-    require(runtime.currentActionId() == "idle_stand", "未知 expression state 应回退到当前 PetState");
+    require(runtime.currentActionId() == "crossed", "未知 expression state 应回退到当前 PetState 的 neutral 映射");
 
     {
         int boundaryCallbacks = 0;

--- a/apps/desktop/tests/pet_runtime_smoke.cpp
+++ b/apps/desktop/tests/pet_runtime_smoke.cpp
@@ -685,6 +685,18 @@ int main(int argc, char *argv[])
         require(turnBoundaryCallbacks == 1, "边界通知不应吞掉 handleAnimationFinished 的原有流程");
         require(runtime.currentFacing() == "left", "边界通知后仍应应用转身动作的 facingAfter");
         require(runtime.currentActionId() == "idle_stand", "边界通知后 onceThenIdle 动作仍应回到 idle_stand");
+
+        int replacedBoundaryCallbacks = 0;
+        runtime.playAction("bow");
+        runtime.requestBoundaryAndNotify([&replacedBoundaryCallbacks]() {
+            ++replacedBoundaryCallbacks;
+        });
+        runtime.returnToIdle();
+        require(replacedBoundaryCallbacks == 1,
+                "替换当前动画时应释放旧 boundary callback，避免悬挂到下一段动画");
+        runtime.handleAnimationFinished();
+        require(replacedBoundaryCallbacks == 1,
+                "旧 boundary callback 不应在后续无关动画结束时重复触发");
     }
 
     runtime.playRecipe("doubleClick.holdIt");

--- a/apps/desktop/tests/pet_runtime_smoke.cpp
+++ b/apps/desktop/tests/pet_runtime_smoke.cpp
@@ -656,6 +656,26 @@ int main(int argc, char *argv[])
     runtime.submitExpressionRequest("unknown-state", "neutral", 0.0);
     require(runtime.currentActionId() == "idle_stand", "未知 expression state 应回退到当前 PetState");
 
+    {
+        int boundaryCallbacks = 0;
+        runtime.playAction("bow");
+        runtime.requestBoundaryAndNotify([&boundaryCallbacks]() {
+            ++boundaryCallbacks;
+        });
+        require(boundaryCallbacks == 0, "requestBoundaryAndNotify 不应在动作边界前回调");
+        runtime.handleAnimationFinished();
+        require(boundaryCallbacks == 1, "requestBoundaryAndNotify 应在 handleAnimationFinished 自然边界回调");
+
+        int cleanFinishCallbacks = 0;
+        runtime.playAction("idle_thinking_once");
+        runtime.requestCleanFinishAndNotify([&cleanFinishCallbacks]() {
+            ++cleanFinishCallbacks;
+        });
+        require(cleanFinishCallbacks == 0, "requestCleanFinishAndNotify 不应在动作边界前回调");
+        runtime.handleAnimationFinished();
+        require(cleanFinishCallbacks == 1, "requestCleanFinishAndNotify 应在 handleAnimationFinished 自然边界回调");
+    }
+
     runtime.playRecipe("doubleClick.holdIt");
     require(runtime.currentActionId() == "crossed", "Hold it 应播放抱臂动作");
     require(runtime.currentSoundUrl().toString() == "qrc:/skins/miles-edgeworth/assets/audio/voice/holdit0.wav", "Hold it 应播放默认语音");

--- a/apps/desktop/tests/pet_runtime_smoke.cpp
+++ b/apps/desktop/tests/pet_runtime_smoke.cpp
@@ -674,6 +674,17 @@ int main(int argc, char *argv[])
         require(cleanFinishCallbacks == 0, "requestCleanFinishAndNotify 不应在动作边界前回调");
         runtime.handleAnimationFinished();
         require(cleanFinishCallbacks == 1, "requestCleanFinishAndNotify 应在 handleAnimationFinished 自然边界回调");
+
+        runtime.setFacing("right");
+        runtime.playRecipe("turn.once");
+        int turnBoundaryCallbacks = 0;
+        runtime.requestBoundaryAndNotify([&turnBoundaryCallbacks]() {
+            ++turnBoundaryCallbacks;
+        });
+        runtime.handleAnimationFinished();
+        require(turnBoundaryCallbacks == 1, "边界通知不应吞掉 handleAnimationFinished 的原有流程");
+        require(runtime.currentFacing() == "left", "边界通知后仍应应用转身动作的 facingAfter");
+        require(runtime.currentActionId() == "idle_stand", "边界通知后 onceThenIdle 动作仍应回到 idle_stand");
     }
 
     runtime.playRecipe("doubleClick.holdIt");

--- a/docs/superpowers/plans/2026-05-22-logging-standard.md
+++ b/docs/superpowers/plans/2026-05-22-logging-standard.md
@@ -1,0 +1,1647 @@
+# 日志规范落地 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the unified Qt + Go logging standard defined in `docs/v2/设计方案/日志规范设计.md`, replacing ad-hoc debug plumbing with categorized, filtered, safe, file-capable logs.
+
+**Architecture:** Qt owns a small `logging` module that installs a custom `qInstallMessageHandler`, formats only `miles.*` categories, writes stderr, and optionally writes a truncated-per-run log file. Go sidecar owns a small `internal/mileslog` package that initializes itself from env vars, exposes `mileslog.New("MILES.*")`, formats records through a custom `slog.Handler`, supports optional payload logging, and writes stderr plus optional append-mode file output. ChatController forwards sidecar stderr directly and passes logging env vars through `QProcessEnvironment`.
+
+**Tech Stack:** Qt 6 / C++17 (`QLoggingCategory`, `qInstallMessageHandler`, `qFormatLogMessage`, `QProcess`), Go 1.22 (`log/slog`, custom handler, `runtime.CallersFrames`), CMake/Ninja/CTest, Python 3 static contract check. No new third-party dependencies.
+
+---
+
+## Scope Check
+
+This plan implements the logging standard only.
+
+Included:
+- Qt `miles.*` custom formatting: `HH:MM:SS.mmm LEVEL [MILES.X] message key=value [File.cpp:line]`.
+- Qt optional `MILES_LOG_FILE`: truncate at app startup, then write through one file handle; file lines include date.
+- Qt leaves non-`miles.*` categories in Qt default formatting and optionally writes them to the same file.
+- Go `internal/mileslog` custom `slog.Handler` with category, source extraction from `record.PC`, env-driven level, and optional file output.
+- Go replacement of `log.Printf`, `debugf`, `SetDebugLogging`, and `MILES_DEBUG_CHAT`.
+- Payload safety: no API key ever logged; user/model raw text only when `MILES_LOG_PAYLOADS=1`.
+- ChatController sidecar process logging cleanup: forward sidecar stderr instead of re-logging it through `miles.chat`.
+- Static contract check and smoke tests for both logging implementations.
+
+Excluded:
+- Log rotation, compression, retention policy.
+- UI log viewer.
+- Remote logging / telemetry / Langfuse.
+- Changing provider behavior or chat protocol.
+- Broad refactors outside logging callsites.
+
+## Assumptions
+
+- Execution starts from `/Users/tian/projects/my-projects/MilesEdgeworth`.
+- The current branch may already contain documentation-only changes. Commit those before implementation or intentionally carry them into the first docs commit; do not mix user-local `.vscode/` changes unless explicitly requested.
+- `docs/v2/设计方案/日志规范设计.md` is the source of truth for formatting, environment variables, payload policy, and category names.
+- Current build already includes Phase 2.3.1 changes: `ChatController`, `PetRuntime`, and `ExpressionMappingResolver` use `Q_LOGGING_CATEGORY(..., QtInfoMsg)`.
+- Go sidecar currently uses `log.Printf`, `MILES_DEBUG_CHAT`, `openai.SetDebugLogging`, and `debugf`; this plan removes those.
+
+## Required Reading
+
+Before implementing, read:
+- `docs/v2/设计方案/日志规范设计.md` all sections.
+- `apps/desktop/src/main.cpp` for app startup order.
+- `apps/desktop/src/chat/ChatController.cpp` constructor and `launchSidecarProcess()`.
+- `apps/agent-core/cmd/miles-agent/main.go`.
+- `apps/agent-core/internal/chat/openai/provider.go`.
+- Existing tests: `apps/agent-core/internal/chat/openai/provider_test.go`, `apps/desktop/tests/chat_controller_smoke.cpp`.
+
+## File Structure
+
+Create:
+- `apps/agent-core/internal/mileslog/mileslog.go`
+  - Self-initializing Go logging package. Exports `New(category string) *slog.Logger` and `PayloadLoggingEnabled() bool`.
+- `apps/agent-core/internal/mileslog/mileslog_test.go`
+  - Unit tests for format, category, source extraction, level filtering, payload flag parsing.
+- `apps/desktop/src/logging/MilesLogHandler.h`
+  - Qt logging install function and testable formatting helpers.
+- `apps/desktop/src/logging/MilesLogHandler.cpp`
+  - Custom message handler, optional file sink, `miles.*` formatting, fallback default formatting for non-project categories.
+- `apps/desktop/tests/logging_formatter_smoke.cpp`
+  - C++ smoke test for category detection and formatting helpers.
+- `tests/check_logging_standard.py`
+  - Static contract check for the logging standard.
+
+Modify:
+- `CMakeLists.txt`
+  - Register `check_logging_standard`.
+- `apps/desktop/CMakeLists.txt`
+  - Add logging module sources to `DESKTOP_SOURCES`; add `LoggingFormatterSmoke` test target.
+- `apps/desktop/src/main.cpp`
+  - Include `logging/MilesLogHandler.h`; call `MilesLogHandler::install()` before creating noisy subsystems.
+- `apps/desktop/src/chat/ChatController.cpp`
+  - Remove `logProcessOutput`, `readyReadStandardError`, `readyReadStandardOutput`; set `ForwardedErrorChannel`; forward `MILES_LOG_*` env vars; update launch log keys.
+- `apps/desktop/src/pet/PetRuntime.cpp`
+  - Normalize existing `miles.pet.runtime` / `miles.pet.expression` logs to no-quote `key=value` style where needed.
+- `apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp`
+  - Normalize existing expression logs to no-quote `key=value` style where needed.
+- `apps/agent-core/cmd/miles-agent/main.go`
+  - Replace `log.Printf` / `log.Fatalf`; remove `MILES_DEBUG_CHAT` setup; use `mileslog.New("MILES.SIDECAR")`.
+- `apps/agent-core/internal/api/server.go`
+  - Add `mileslog.New("MILES.SIDECAR")` for request-level warnings/errors if needed by implementation.
+- `apps/agent-core/internal/chat/openai/provider.go`
+  - Replace `debugf` / `SetDebugLogging` with `logger.Debug`; add guarded payload logs.
+- `tests/check_phase_2_1_provider.py`
+  - Replace `MILES_DEBUG_CHAT` expectations if any exist.
+- `docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md`
+  - No required change unless final verification notes discover a logging-related caveat worth recording.
+
+Not modified:
+- `docs/v2/设计方案/日志规范设计.md` unless implementation reveals an actual design bug.
+- QML UI.
+- Provider request/response protocol.
+- Secret storage behavior.
+
+---
+
+## Task 0: Preflight and Documentation Baseline
+
+**Files:**
+- Read-only unless committing existing docs.
+
+- [ ] **Step 1: Check working tree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: current branch is the active Phase 2 branch. Existing dirty docs are acceptable only if they are intentional. `.vscode/` should remain untracked unless the user explicitly asks to commit it.
+
+- [ ] **Step 2: Commit existing documentation changes if still dirty**
+
+If `docs/v2/设计方案/日志规范设计.md`, `docs/v2/文档索引.md`, or `docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md` are dirty from the design-review work, commit them before implementation:
+
+```bash
+git add \
+  "docs/v2/设计方案/日志规范设计.md" \
+  "docs/v2/文档索引.md" \
+  "docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md"
+git commit -m "docs: 完善日志规范设计"
+```
+
+Expected: a docs-only commit. Do not stage `.vscode/`.
+
+- [ ] **Step 3: Verify baseline tests**
+
+Run:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew
+ctest --test-dir build -R "check_phase_2_1_provider|check_phase_2_2_settings|check_phase_2_3_1_animation_sync|chat_controller_smoke|pet_runtime_smoke" --output-on-failure
+(cd apps/agent-core && go test ./...)
+```
+
+Expected: all pass before logging work starts.
+
+- [ ] **Step 4: No implementation commit**
+
+Task 0 changes nothing except the optional docs-baseline commit.
+
+---
+
+## Task 1: Static Logging Contract Scaffold
+
+**Files:**
+- Create: `tests/check_logging_standard.py`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create `tests/check_logging_standard.py`:
+
+```python
+#!/usr/bin/env python3
+"""Check the unified logging-standard implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    file_path = ROOT / path
+    if not file_path.exists():
+        raise AssertionError(f"missing file: {path}")
+    return file_path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    mileslog = read("apps/agent-core/internal/mileslog/mileslog.go")
+    mileslog_test = read("apps/agent-core/internal/mileslog/mileslog_test.go")
+    main_go = read("apps/agent-core/cmd/miles-agent/main.go")
+    provider_go = read("apps/agent-core/internal/chat/openai/provider.go")
+    qt_handler_h = read("apps/desktop/src/logging/MilesLogHandler.h")
+    qt_handler_cpp = read("apps/desktop/src/logging/MilesLogHandler.cpp")
+    qt_handler_smoke = read("apps/desktop/tests/logging_formatter_smoke.cpp")
+    desktop_main = read("apps/desktop/src/main.cpp")
+    chat_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    desktop_cmake = read("apps/desktop/CMakeLists.txt")
+    root_cmake = read("CMakeLists.txt")
+
+    require("package mileslog" in mileslog, "Go mileslog package must exist")
+    require("func New(category string) *slog.Logger" in mileslog,
+            "mileslog.New(category) must be exported")
+    require("func PayloadLoggingEnabled() bool" in mileslog,
+            "mileslog must expose PayloadLoggingEnabled")
+    require("type handler struct" in mileslog and "slog.Handler" in mileslog,
+            "mileslog must implement a custom slog.Handler")
+    require("runtime.CallersFrames" in mileslog and "record.PC" in mileslog,
+            "mileslog must extract source from record.PC")
+    require("MILES_LOG_LEVEL" in mileslog and "MILES_LOG_FILE" in mileslog
+            and "MILES_LOG_PAYLOADS" in mileslog,
+            "mileslog must read all logging env vars")
+    require("WithGroup" not in mileslog,
+            "mileslog must not use slog.WithGroup for category")
+    require("category" in mileslog and "MILES." in mileslog_test,
+            "mileslog tests must cover category formatting")
+
+    require("MILES_DEBUG_CHAT" not in main_go + provider_go,
+            "MILES_DEBUG_CHAT must be removed")
+    require("SetDebugLogging" not in provider_go,
+            "openai.SetDebugLogging must be removed")
+    require("debugf(" not in provider_go,
+            "provider debugf helper must be removed")
+    require("log.Printf" not in main_go + provider_go,
+            "sidecar must not use log.Printf")
+    require("log.Fatalf" not in main_go + provider_go,
+            "sidecar must not use log.Fatalf")
+    require("mileslog.New(\"MILES.SIDECAR\")" in main_go,
+            "main.go must use MILES.SIDECAR logger")
+    require("mileslog.New(\"MILES.CHAT.PROVIDER\")" in provider_go,
+            "provider.go must use MILES.CHAT.PROVIDER logger")
+
+    require("namespace MilesLogHandler" in qt_handler_h,
+            "Qt logging handler namespace must be declared")
+    require("void install()" in qt_handler_h,
+            "Qt logging handler must expose install()")
+    require("qInstallMessageHandler" in qt_handler_cpp,
+            "Qt logging handler must install a message handler")
+    require("qFormatLogMessage" in qt_handler_cpp,
+            "Qt logging handler must preserve default formatting for non-miles categories")
+    require("MILES_LOG_FILE" in qt_handler_cpp,
+            "Qt logging handler must support MILES_LOG_FILE")
+    require("miles.*" in qt_handler_cpp or "miles." in qt_handler_cpp,
+            "Qt logging handler must special-case miles.* categories")
+    require("MilesLogHandler::install()" in desktop_main,
+            "main.cpp must install the Qt logging handler")
+    require("LoggingFormatterSmoke" in desktop_cmake and "logging_formatter_smoke" in desktop_cmake,
+            "Qt logging formatter smoke test must be registered")
+    require("check_logging_standard" in root_cmake,
+            "root CMake must register check_logging_standard")
+
+    require("ForwardedErrorChannel" in chat_cpp,
+            "ChatController must forward sidecar stderr")
+    require("readyReadStandardError" not in chat_cpp,
+            "ChatController must not re-log sidecar stderr")
+    require("logProcessOutput" not in chat_cpp,
+            "ChatController logProcessOutput helper must be removed")
+    require("MILES_LOG_PAYLOADS" in chat_cpp,
+            "ChatController must forward MILES_LOG_PAYLOADS to sidecar")
+
+    print("logging standard contract ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Register the contract test**
+
+In root `CMakeLists.txt`, near the existing Phase 2 contract tests, add:
+
+```cmake
+        # Logging standard check: keeps Qt + Go logging categories, env vars,
+        # payload safety, and sidecar stderr forwarding aligned with docs/v2/设计方案/日志规范设计.md.
+        add_test(
+            NAME check_logging_standard
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_logging_standard.py
+        )
+```
+
+- [ ] **Step 3: Verify the contract fails for missing implementation**
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: FAIL with `missing file: apps/agent-core/internal/mileslog/mileslog.go`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/check_logging_standard.py CMakeLists.txt
+git commit -m "test: 增加日志规范契约检查"
+```
+
+---
+
+## Task 2: Go `mileslog` Package
+
+**Files:**
+- Create: `apps/agent-core/internal/mileslog/mileslog.go`
+- Create: `apps/agent-core/internal/mileslog/mileslog_test.go`
+
+- [ ] **Step 1: Write failing Go tests**
+
+Create `apps/agent-core/internal/mileslog/mileslog_test.go`:
+
+```go
+package mileslog
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestHandlerFormatsCategoryMessageAttrsAndSource(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelDebug)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Debug("stream event", "deltaLen", 3, "state", "speaking")
+
+	got := buf.String()
+	for _, want := range []string{
+		"DEBUG",
+		"[MILES.TEST]",
+		"stream event",
+		"deltaLen=3",
+		"state=speaking",
+		"[mileslog_test.go:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted log missing %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "time=") || strings.Contains(got, "msg=") {
+		t.Fatalf("custom handler must not use slog TextHandler format: %q", got)
+	}
+}
+
+func TestHandlerFiltersBelowConfiguredLevel(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: false}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Debug("hidden")
+	logger.Info("shown")
+
+	got := buf.String()
+	if strings.Contains(got, "hidden") {
+		t.Fatalf("debug log should be filtered at info level: %q", got)
+	}
+	if !strings.Contains(got, "shown") {
+		t.Fatalf("info log should be emitted: %q", got)
+	}
+}
+
+func TestHandlerAddsDateForFileSink(t *testing.T) {
+	var buf bytes.Buffer
+	h := newHandler([]sink{{writer: &buf, includeDate: true}}, slog.LevelInfo)
+	logger := slog.New(h).With("category", "MILES.TEST")
+
+	logger.Info("file line")
+
+	got := buf.String()
+	if len(got) < len("2006-01-02 15:04:05.000") || got[4] != '-' || got[13] != ':' {
+		t.Fatalf("file sink should include full date timestamp, got %q", got)
+	}
+}
+
+func TestPayloadFlagParser(t *testing.T) {
+	t.Setenv("MILES_LOG_PAYLOADS", "1")
+	if !payloadLoggingEnabledFromEnv() {
+		t.Fatal("MILES_LOG_PAYLOADS=1 should enable payload logging")
+	}
+	t.Setenv("MILES_LOG_PAYLOADS", "0")
+	if payloadLoggingEnabledFromEnv() {
+		t.Fatal("MILES_LOG_PAYLOADS=0 should disable payload logging")
+	}
+}
+
+func TestEnabledHonorsLevel(t *testing.T) {
+	h := newHandler([]sink{{writer: &bytes.Buffer{}, includeDate: false}}, slog.LevelWarn)
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("info should be disabled at warn level")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Fatal("error should be enabled at warn level")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cd apps/agent-core
+go test ./internal/mileslog
+```
+
+Expected: FAIL because package files do not exist or `newHandler` is undefined.
+
+- [ ] **Step 3: Implement `mileslog`**
+
+Create `apps/agent-core/internal/mileslog/mileslog.go`:
+
+```go
+package mileslog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type sink struct {
+	writer      io.Writer
+	includeDate bool
+}
+
+type handler struct {
+	mu    *sync.Mutex
+	sinks []sink
+	level slog.Level
+	attrs []slog.Attr
+}
+
+var (
+	defaultLogger *slog.Logger
+	payloads      bool
+)
+
+func init() {
+	payloads = payloadLoggingEnabledFromEnv()
+	defaultLogger = slog.New(newHandler(defaultSinks(), parseLevel(os.Getenv("MILES_LOG_LEVEL"))))
+}
+
+func New(category string) *slog.Logger {
+	if defaultLogger == nil {
+		defaultLogger = slog.New(newHandler(defaultSinks(), slog.LevelInfo))
+	}
+	return defaultLogger.With("category", strings.ToUpper(strings.TrimSpace(category)))
+}
+
+func PayloadLoggingEnabled() bool {
+	return payloads
+}
+
+func payloadLoggingEnabledFromEnv() bool {
+	return os.Getenv("MILES_LOG_PAYLOADS") == "1"
+}
+
+func parseLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func defaultSinks() []sink {
+	sinks := []sink{{writer: os.Stderr, includeDate: false}}
+	if path := strings.TrimSpace(os.Getenv("MILES_LOG_FILE")); path != "" {
+		if file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+			sinks = append(sinks, sink{writer: file, includeDate: true})
+		}
+	}
+	return sinks
+}
+
+func newHandler(sinks []sink, level slog.Level) *handler {
+	return &handler{
+		mu:    &sync.Mutex{},
+		sinks: sinks,
+		level: level,
+	}
+}
+
+func (h *handler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *handler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make([]slog.Attr, 0, len(h.attrs)+record.NumAttrs())
+	attrs = append(attrs, h.attrs...)
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+
+	category := "MILES.APP"
+	filtered := attrs[:0]
+	for _, attr := range attrs {
+		if attr.Key == "category" {
+			if value := strings.TrimSpace(attr.Value.String()); value != "" {
+				category = strings.ToUpper(value)
+			}
+			continue
+		}
+		filtered = append(filtered, attr)
+	}
+
+	source := sourceLocation(record.PC)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, sink := range h.sinks {
+		line := formatLine(record.Time, record.Level, category, record.Message, filtered, source, sink.includeDate)
+		if _, err := io.WriteString(sink.writer, line+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	next := *h
+	next.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &next
+}
+
+func (h *handler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+func formatLine(t time.Time, level slog.Level, category string, message string, attrs []slog.Attr, source string, includeDate bool) string {
+	if t.IsZero() {
+		t = time.Now()
+	}
+	layout := "15:04:05.000"
+	if includeDate {
+		layout = "2006-01-02 15:04:05.000"
+	}
+	parts := []string{
+		t.Format(layout),
+		paddedLevel(level),
+		"[" + category + "]",
+		message,
+	}
+	for _, attr := range attrs {
+		parts = append(parts, attr.Key+"="+attrValueString(attr.Value))
+	}
+	if source != "" {
+		parts = append(parts, "["+source+"]")
+	}
+	return strings.Join(parts, " ")
+}
+
+func paddedLevel(level slog.Level) string {
+	switch {
+	case level <= slog.LevelDebug:
+		return "DEBUG"
+	case level < slog.LevelWarn:
+		return "INFO "
+	case level < slog.LevelError:
+		return "WARN "
+	default:
+		return "ERROR"
+	}
+}
+
+func attrValueString(value slog.Value) string {
+	var text string
+	switch value.Kind() {
+	case slog.KindString:
+		text = value.String()
+	default:
+		text = fmt.Sprint(value.Any())
+	}
+	if text == "" {
+		return `""`
+	}
+	if strings.ContainsAny(text, " \t\r\n") {
+		return strconv.Quote(text)
+	}
+	return text
+}
+
+func sourceLocation(pc uintptr) string {
+	if pc == 0 {
+		return ""
+	}
+	frames := runtime.CallersFrames([]uintptr{pc})
+	frame, _ := frames.Next()
+	if frame.File == "" {
+		return ""
+	}
+	return filepath.Base(frame.File) + ":" + strconv.Itoa(frame.Line)
+}
+```
+
+- [ ] **Step 4: Run Go tests**
+
+Run:
+
+```bash
+cd apps/agent-core
+go test ./internal/mileslog
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/agent-core/internal/mileslog/mileslog.go apps/agent-core/internal/mileslog/mileslog_test.go
+git commit -m "feat: 增加 sidecar 日志封装"
+```
+
+---
+
+## Task 3: Migrate Sidecar Logging
+
+**Files:**
+- Modify: `apps/agent-core/cmd/miles-agent/main.go`
+- Modify: `apps/agent-core/internal/chat/openai/provider.go`
+- Modify: `apps/agent-core/internal/chat/openai/provider_test.go`
+- Modify: `tests/check_phase_2_1_provider.py` if it references `MILES_DEBUG_CHAT`
+
+- [ ] **Step 1: Write failing migration assertions**
+
+Append to `apps/agent-core/internal/chat/openai/provider_test.go`:
+
+```go
+func TestPayloadLoggingFlagDoesNotAffectStreamEvents(t *testing.T) {
+	t.Setenv("MILES_LOG_PAYLOADS", "1")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"[EXPR:polite]secret text\"}}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	p := openai.NewProvider(upstream.URL, "sk-test", "any", 0.7, 128)
+	events, err := p.StreamReply(context.Background(), chat.Request{
+		Message:     "hi",
+		Expressions: []chat.ExpressionInfo{{ID: "polite"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamReply: %v", err)
+	}
+	seenText := false
+	for event := range events {
+		if event.Type == "TEXT_MESSAGE_CONTENT" && event.Delta == "secret text" {
+			seenText = true
+		}
+	}
+	if !seenText {
+		t.Fatal("payload logging flag must not change stream parsing")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify compile failure**
+
+Run:
+
+```bash
+cd apps/agent-core
+go test ./...
+```
+
+Expected: currently may still PASS because the test is behavioral. The real migration is enforced by `python3 tests/check_logging_standard.py`, which still fails on `MILES_DEBUG_CHAT`, `debugf`, and `log.Printf`.
+
+- [ ] **Step 3: Migrate `main.go`**
+
+In `apps/agent-core/cmd/miles-agent/main.go`:
+
+Remove imports:
+
+```go
+	"log"
+```
+
+Add import:
+
+```go
+	"milesedgeworth/agent-core/internal/mileslog"
+```
+
+Add package-level logger after imports:
+
+```go
+var logger = mileslog.New("MILES.SIDECAR")
+```
+
+Delete this block:
+
+```go
+	debugChat := os.Getenv("MILES_DEBUG_CHAT") != ""
+	openai.SetDebugLogging(debugChat)
+	if debugChat {
+		log.Printf("debug chat diagnostics enabled")
+	}
+```
+
+Replace logging calls:
+
+```go
+logger.Info("provider selected", "provider", "openai-compatible", "model", cfg.Model)
+logger.Info("provider selected", "provider", "mock-fallback")
+logger.Info("server listening", "addr", *addr)
+logger.Info("shutdown requested", "signal", sig.String())
+logger.Error("shutdown failed", "error", err)
+logger.Error("server failed", "error", err)
+```
+
+For fatal paths, log then exit:
+
+```go
+if err := server.Shutdown(ctx); err != nil {
+	logger.Error("shutdown failed", "error", err)
+	os.Exit(1)
+}
+```
+
+and:
+
+```go
+if err != nil && err != http.ErrServerClosed {
+	logger.Error("server failed", "error", err)
+	os.Exit(1)
+}
+```
+
+- [ ] **Step 4: Migrate `provider.go` logger**
+
+In `apps/agent-core/internal/chat/openai/provider.go`:
+
+Remove import:
+
+```go
+	"log"
+```
+
+Add import:
+
+```go
+	"milesedgeworth/agent-core/internal/mileslog"
+```
+
+Delete:
+
+```go
+var debugLoggingEnabled bool
+
+func SetDebugLogging(enabled bool) {
+	debugLoggingEnabled = enabled
+}
+
+func debugf(format string, args ...any) {
+	if debugLoggingEnabled {
+		log.Printf("debug chat.openai: "+format, args...)
+	}
+}
+```
+
+Add package-level logger:
+
+```go
+var logger = mileslog.New("MILES.CHAT.PROVIDER")
+```
+
+Replace debug calls with structured calls:
+
+```go
+logger.Debug("request prepared",
+	"model", p.model,
+	"endpoint", sanitizeEndpoint(p.baseURL),
+	"expressions", len(req.Expressions),
+	"messageLen", len([]rune(req.Message)))
+```
+
+```go
+logger.Debug("stream started", "knownTags", strings.Join(knownTags, ","))
+```
+
+```go
+logger.Debug("fallback expression inserted",
+	"expression", "neutral",
+	"textLen", len([]rune(text)))
+```
+
+```go
+logger.Debug("text chunk parsed", "len", len([]rune(text)))
+```
+
+```go
+logger.Debug("expression tag parsed", "tag", tag)
+```
+
+```go
+logger.Debug("provider delta received", "len", len([]rune(choice.Delta.Content)))
+if mileslog.PayloadLoggingEnabled() {
+	logger.Debug("provider delta payload", "text", choice.Delta.Content)
+}
+```
+
+```go
+logger.Debug("stream finished")
+```
+
+When skipping malformed chunks, add a warning:
+
+```go
+if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+	logger.Warn("malformed provider chunk skipped", "error", err)
+	if mileslog.PayloadLoggingEnabled() {
+		logger.Debug("malformed provider payload", "payload", payload)
+	}
+	continue
+}
+```
+
+- [ ] **Step 5: Update stale contract references**
+
+Run:
+
+```bash
+rg -n "MILES_DEBUG_CHAT|SetDebugLogging|debugf|log\\.Printf|log\\.Fatalf" apps/agent-core tests
+```
+
+Expected after edits: no matches except historical documentation if any. If `tests/check_phase_2_1_provider.py` requires `MILES_DEBUG_CHAT`, update it to require `MILES_LOG_LEVEL` / `mileslog.New`.
+
+- [ ] **Step 6: Verify Go**
+
+Run:
+
+```bash
+cd apps/agent-core
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify contract progress**
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: still FAIL because Qt logging handler is missing, but no longer fails on Go `MILES_DEBUG_CHAT`, `debugf`, or `log.Printf`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/agent-core/cmd/miles-agent/main.go \
+  apps/agent-core/internal/chat/openai/provider.go \
+  apps/agent-core/internal/chat/openai/provider_test.go \
+  tests/check_phase_2_1_provider.py
+git commit -m "feat: 迁移 sidecar 日志"
+```
+
+If `tests/check_phase_2_1_provider.py` was not changed, omit it from `git add`.
+
+---
+
+## Task 4: Qt Logging Handler and Formatter Smoke Test
+
+**Files:**
+- Create: `apps/desktop/src/logging/MilesLogHandler.h`
+- Create: `apps/desktop/src/logging/MilesLogHandler.cpp`
+- Create: `apps/desktop/tests/logging_formatter_smoke.cpp`
+- Modify: `apps/desktop/CMakeLists.txt`
+- Modify: `apps/desktop/src/main.cpp`
+
+- [ ] **Step 1: Write failing Qt smoke test**
+
+Create `apps/desktop/tests/logging_formatter_smoke.cpp`:
+
+```cpp
+#include "logging/MilesLogHandler.h"
+
+#include <QCoreApplication>
+#include <QMessageLogContext>
+#include <QString>
+
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char *message)
+{
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(1);
+    }
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    require(MilesLogHandler::isMilesCategory("miles.chat"),
+            "miles.chat should be treated as project category");
+    require(!MilesLogHandler::isMilesCategory("qt.qml.binding"),
+            "qt.qml.binding should not be treated as project category");
+
+    QMessageLogContext context("ChatController.cpp", 302, "sendMessage", "miles.chat");
+    const QString consoleLine = MilesLogHandler::formatMilesMessage(
+        QtInfoMsg,
+        context,
+        QStringLiteral("send chat request messageLen=12"),
+        false);
+    require(consoleLine.contains(QStringLiteral("INFO  [MILES.CHAT]")),
+            "console line should contain padded INFO level and upper category");
+    require(consoleLine.contains(QStringLiteral("send chat request messageLen=12")),
+            "console line should contain message");
+    require(consoleLine.endsWith(QStringLiteral("[ChatController.cpp:302]")),
+            "console line should end with source");
+    require(!consoleLine.left(10).contains('-'),
+            "console line should omit date");
+
+    const QString fileLine = MilesLogHandler::formatMilesMessage(
+        QtDebugMsg,
+        context,
+        QStringLiteral("stream event type=CUSTOM"),
+        true);
+    require(fileLine.contains(QStringLiteral("DEBUG [MILES.CHAT]")),
+            "file line should contain DEBUG level and category");
+    require(fileLine.left(10).contains('-'),
+            "file line should include date");
+
+    std::cout << "logging formatter smoke checks passed.\n";
+    return 0;
+}
+```
+
+- [ ] **Step 2: Register test and sources**
+
+In `apps/desktop/CMakeLists.txt`, add to `DESKTOP_SOURCES` near `src/main.cpp`:
+
+```cmake
+    src/logging/MilesLogHandler.cpp
+    src/logging/MilesLogHandler.h
+```
+
+Inside `if(BUILD_TESTING)`, add:
+
+```cmake
+    add_executable(LoggingFormatterSmoke
+        tests/logging_formatter_smoke.cpp
+        src/logging/MilesLogHandler.cpp
+        src/logging/MilesLogHandler.h
+    )
+
+    target_include_directories(LoggingFormatterSmoke
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    target_link_libraries(LoggingFormatterSmoke
+        PRIVATE
+            Qt6::Core
+    )
+
+    add_test(NAME logging_formatter_smoke COMMAND LoggingFormatterSmoke)
+```
+
+- [ ] **Step 3: Run test to verify failure**
+
+Run:
+
+```bash
+cmake --build build --target LoggingFormatterSmoke
+```
+
+Expected: FAIL because `logging/MilesLogHandler.h` does not exist.
+
+- [ ] **Step 4: Add `MilesLogHandler.h`**
+
+Create `apps/desktop/src/logging/MilesLogHandler.h`:
+
+```cpp
+#pragma once
+
+#include <QtGlobal>
+
+class QMessageLogContext;
+class QString;
+
+namespace MilesLogHandler {
+
+void install();
+bool isMilesCategory(const char *category);
+QString formatMilesMessage(QtMsgType type,
+                           const QMessageLogContext &context,
+                           const QString &message,
+                           bool includeDate);
+
+} // namespace MilesLogHandler
+```
+
+- [ ] **Step 5: Add `MilesLogHandler.cpp`**
+
+Create `apps/desktop/src/logging/MilesLogHandler.cpp`:
+
+```cpp
+#include "logging/MilesLogHandler.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QFile>
+#include <QFileInfo>
+#include <QMessageLogContext>
+#include <QMutex>
+#include <QTextStream>
+
+#include <cstdio>
+#include <memory>
+
+namespace {
+
+QtMessageHandler previousHandler = nullptr;
+QMutex logMutex;
+std::unique_ptr<QFile> logFile;
+
+QString levelName(QtMsgType type)
+{
+    switch (type) {
+    case QtDebugMsg:
+        return QStringLiteral("DEBUG");
+    case QtInfoMsg:
+        return QStringLiteral("INFO ");
+    case QtWarningMsg:
+        return QStringLiteral("WARN ");
+    case QtCriticalMsg:
+    case QtFatalMsg:
+        return QStringLiteral("ERROR");
+    }
+    return QStringLiteral("INFO ");
+}
+
+QString sourceName(const QMessageLogContext &context)
+{
+    if (context.file == nullptr || context.line <= 0) {
+        return QString();
+    }
+    return QFileInfo(QString::fromUtf8(context.file)).fileName()
+        + QStringLiteral(":")
+        + QString::number(context.line);
+}
+
+void writeStderr(const QString &line)
+{
+    const QByteArray bytes = line.toLocal8Bit();
+    std::fwrite(bytes.constData(), 1, static_cast<size_t>(bytes.size()), stderr);
+    std::fwrite("\n", 1, 1, stderr);
+    std::fflush(stderr);
+}
+
+void writeFileLine(const QString &line)
+{
+    if (logFile == nullptr || !logFile->isOpen()) {
+        return;
+    }
+    QTextStream stream(logFile.get());
+    stream << line << '\n';
+    stream.flush();
+}
+
+void handleMessage(QtMsgType type, const QMessageLogContext &context, const QString &message)
+{
+    QMutexLocker locker(&logMutex);
+    if (MilesLogHandler::isMilesCategory(context.category)) {
+        writeStderr(MilesLogHandler::formatMilesMessage(type, context, message, false));
+        writeFileLine(MilesLogHandler::formatMilesMessage(type, context, message, true));
+        return;
+    }
+
+    if (previousHandler != nullptr) {
+        previousHandler(type, context, message);
+    } else {
+        writeStderr(qFormatLogMessage(type, context, message));
+    }
+
+    if (logFile != nullptr && logFile->isOpen()) {
+        writeFileLine(qFormatLogMessage(type, context, message));
+    }
+}
+
+} // namespace
+
+namespace MilesLogHandler {
+
+void install()
+{
+    const QByteArray path = qgetenv("MILES_LOG_FILE");
+    if (!path.trimmed().isEmpty()) {
+        logFile = std::make_unique<QFile>(QString::fromLocal8Bit(path));
+        logFile->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text);
+    }
+    previousHandler = qInstallMessageHandler(handleMessage);
+}
+
+bool isMilesCategory(const char *category)
+{
+    if (category == nullptr) {
+        return false;
+    }
+    return QByteArray(category).startsWith("miles.");
+}
+
+QString formatMilesMessage(QtMsgType type,
+                           const QMessageLogContext &context,
+                           const QString &message,
+                           bool includeDate)
+{
+    const QString timestamp = QDateTime::currentDateTime().toString(
+        includeDate ? QStringLiteral("yyyy-MM-dd HH:mm:ss.zzz") : QStringLiteral("HH:mm:ss.zzz"));
+    const QString category = QString::fromUtf8(context.category == nullptr ? "miles.app" : context.category)
+        .toUpper();
+    QString line = timestamp
+        + QStringLiteral(" ")
+        + levelName(type)
+        + QStringLiteral(" [")
+        + category
+        + QStringLiteral("] ")
+        + message;
+    const QString source = sourceName(context);
+    if (!source.isEmpty()) {
+        line += QStringLiteral(" [") + source + QStringLiteral("]");
+    }
+    return line;
+}
+
+} // namespace MilesLogHandler
+```
+
+- [ ] **Step 6: Install handler in app startup**
+
+In `apps/desktop/src/main.cpp`, add include:
+
+```cpp
+#include "logging/MilesLogHandler.h"
+```
+
+At the top of `main`, before `QApplication app(argc, argv);`, add:
+
+```cpp
+    MilesLogHandler::install();
+```
+
+- [ ] **Step 7: Run Qt logging smoke**
+
+Run:
+
+```bash
+cmake --build build --target LoggingFormatterSmoke
+build/apps/desktop/LoggingFormatterSmoke
+```
+
+Expected:
+
+```text
+logging formatter smoke checks passed.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/logging/MilesLogHandler.h \
+  apps/desktop/src/logging/MilesLogHandler.cpp \
+  apps/desktop/tests/logging_formatter_smoke.cpp \
+  apps/desktop/CMakeLists.txt \
+  apps/desktop/src/main.cpp
+git commit -m "feat: 增加 Qt 日志处理器"
+```
+
+---
+
+## Task 5: Sidecar Process Logging Plumbing in ChatController
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Test: `tests/check_logging_standard.py`
+
+- [ ] **Step 1: Write failing contract additions if missing**
+
+Confirm `tests/check_logging_standard.py` already checks:
+
+```python
+require("ForwardedErrorChannel" in chat_cpp,
+        "ChatController must forward sidecar stderr")
+require("readyReadStandardError" not in chat_cpp,
+        "ChatController must not re-log sidecar stderr")
+require("logProcessOutput" not in chat_cpp,
+        "ChatController logProcessOutput helper must be removed")
+require("MILES_LOG_PAYLOADS" in chat_cpp,
+        "ChatController must forward MILES_LOG_PAYLOADS to sidecar")
+```
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: FAIL on `readyReadStandardError`, `logProcessOutput`, or missing `ForwardedErrorChannel`.
+
+- [ ] **Step 2: Remove sidecar stderr/stdout re-logging helper**
+
+In `apps/desktop/src/chat/ChatController.cpp`, delete the full `logProcessOutput` helper:
+
+```cpp
+void logProcessOutput(const char *label, const QByteArray &bytes)
+{
+    const QList<QByteArray> lines = bytes.split('\n');
+    for (QByteArray line : lines) {
+        if (line.endsWith('\r')) {
+            line.chop(1);
+        }
+        if (!line.trimmed().isEmpty()) {
+            qCDebug(chatLog).noquote() << label << QString::fromLocal8Bit(line);
+        }
+    }
+}
+```
+
+Delete these constructor connections:
+
+```cpp
+    connect(&m_sidecarProcess, &QProcess::readyReadStandardError, this, [this]() {
+        logProcessOutput("sidecar stderr", m_sidecarProcess.readAllStandardError());
+    });
+    connect(&m_sidecarProcess, &QProcess::readyReadStandardOutput, this, [this]() {
+        logProcessOutput("sidecar stdout", m_sidecarProcess.readAllStandardOutput());
+    });
+```
+
+- [ ] **Step 3: Forward sidecar stderr**
+
+In the `ChatController` constructor, before `connect(&m_sidecarProcess, &QProcess::started, ...)`, add:
+
+```cpp
+    m_sidecarProcess.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+```
+
+- [ ] **Step 4: Make log env forwarding explicit**
+
+In `launchSidecarProcess()`, immediately after:
+
+```cpp
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+```
+
+add:
+
+```cpp
+    const QProcessEnvironment systemEnv = QProcessEnvironment::systemEnvironment();
+    const QStringList logEnvNames{
+        QStringLiteral("MILES_LOG_FILE"),
+        QStringLiteral("MILES_LOG_LEVEL"),
+        QStringLiteral("MILES_LOG_PAYLOADS"),
+    };
+    for (const QString &name : logEnvNames) {
+        if (systemEnv.contains(name)) {
+            env.insert(name, systemEnv.value(name));
+        }
+    }
+```
+
+This is redundant with `systemEnvironment()` today, but makes the logging contract explicit and robust if `env` is later constructed from scratch.
+
+- [ ] **Step 5: Update launch debug keys**
+
+Replace the old `debug=` field:
+
+```cpp
+                     << "debug=" << env.contains(QStringLiteral("MILES_DEBUG_CHAT"));
+```
+
+with no-quote key/value fields:
+
+```cpp
+                     << QStringLiteral("logLevel=%1").arg(env.value(QStringLiteral("MILES_LOG_LEVEL"), QStringLiteral("info")))
+                     << QStringLiteral("logFileSet=%1").arg(env.contains(QStringLiteral("MILES_LOG_FILE")))
+                     << QStringLiteral("payloads=%1").arg(env.value(QStringLiteral("MILES_LOG_PAYLOADS")) == QStringLiteral("1"));
+```
+
+Also convert the whole launch log to `.noquote()`:
+
+```cpp
+    qCDebug(chatLog).noquote() << "launch sidecar"
+                               << QStringLiteral("path=%1").arg(executablePath)
+                               << QStringLiteral("baseUrlSet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_BASE_URL")))
+                               << QStringLiteral("apiKeySet=%1").arg(env.contains(QStringLiteral("MILES_PROVIDER_API_KEY")))
+                               << QStringLiteral("model=%1").arg(env.value(QStringLiteral("MILES_PROVIDER_MODEL")))
+                               << QStringLiteral("logLevel=%1").arg(env.value(QStringLiteral("MILES_LOG_LEVEL"), QStringLiteral("info")))
+                               << QStringLiteral("logFileSet=%1").arg(env.contains(QStringLiteral("MILES_LOG_FILE")))
+                               << QStringLiteral("payloads=%1").arg(env.value(QStringLiteral("MILES_LOG_PAYLOADS")) == QStringLiteral("1"));
+```
+
+- [ ] **Step 6: Verify contract**
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: may still FAIL on remaining Qt log normalization, but must no longer fail on sidecar forwarding.
+
+- [ ] **Step 7: Build ChatControllerSmoke**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke
+build/apps/desktop/ChatControllerSmoke
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.cpp tests/check_logging_standard.py
+git commit -m "feat: 转发 sidecar 日志输出"
+```
+
+If `tests/check_logging_standard.py` did not change in this task, omit it from `git add`.
+
+---
+
+## Task 6: Normalize Project Log Calls and Payload Safety
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Modify: `apps/desktop/src/pet/PetRuntime.cpp`
+- Modify: `apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp`
+- Modify: `apps/agent-core/internal/chat/openai/provider.go`
+
+- [ ] **Step 1: Add no-quote formatting rule to contract**
+
+Extend `tests/check_logging_standard.py` with:
+
+```python
+    require(".noquote()" in chat_cpp,
+            "ChatController should use noquote key=value debug logs")
+    runtime_cpp = read("apps/desktop/src/pet/PetRuntime.cpp")
+    expression_cpp = read("apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp")
+    require(".noquote()" in runtime_cpp,
+            "PetRuntime should use noquote key=value debug logs")
+    require(".noquote()" in expression_cpp,
+            "ExpressionMappingResolver should use noquote key=value debug logs")
+    require("PayloadLoggingEnabled" in provider_go,
+            "provider must guard raw payload logs behind MILES_LOG_PAYLOADS")
+```
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: FAIL until the Qt callsites are normalized.
+
+- [ ] **Step 2: Normalize ChatController logs**
+
+For `ChatController.cpp`, convert current `qCDebug(chatLog) <<` calls to `.noquote()` and `QStringLiteral("key=%1").arg(...)` style. Examples:
+
+```cpp
+qCDebug(chatLog).noquote() << "sidecar process started"
+                           << QStringLiteral("pid=%1").arg(m_sidecarProcess.processId())
+                           << QStringLiteral("program=%1").arg(m_sidecarProcess.program());
+```
+
+```cpp
+qCDebug(chatLog).noquote() << "sidecar health"
+                           << QStringLiteral("healthy=%1").arg(healthy)
+                           << QStringLiteral("pid=%1").arg(healthPid)
+                           << QStringLiteral("ownedPid=%1").arg(ownedPid)
+                           << QStringLiteral("provider=%1").arg(health.value(QStringLiteral("provider")).toString())
+                           << QStringLiteral("error=%1").arg(reply->errorString());
+```
+
+```cpp
+qCDebug(chatLog).noquote() << "stream event"
+                           << QStringLiteral("type=%1").arg(event.type)
+                           << QStringLiteral("name=%1").arg(event.name)
+                           << QStringLiteral("state=%1").arg(event.value.value(QStringLiteral("state")).toString())
+                           << QStringLiteral("expression=%1").arg(event.value.value(QStringLiteral("expression")).toString())
+                           << QStringLiteral("deltaLen=%1").arg(event.delta.size());
+```
+
+Do not log user message text or model text. Keep `messageLen` and `deltaLen` only.
+
+- [ ] **Step 3: Normalize PetRuntime logs**
+
+For `PetRuntime.cpp`, convert logs to `.noquote()`. Examples:
+
+```cpp
+qCDebug(petRuntimeLog).noquote() << "execute action request"
+                                 << QStringLiteral("kind=%1").arg(static_cast<int>(request.kind))
+                                 << QStringLiteral("target=%1").arg(request.target)
+                                 << QStringLiteral("state=%1").arg(request.state)
+                                 << QStringLiteral("interruptHint=%1").arg(static_cast<int>(request.interruptHint));
+```
+
+```cpp
+qCDebug(petRuntimeLog).noquote() << "set current phase"
+                                 << QStringLiteral("action=%1").arg(m_currentActionId)
+                                 << QStringLiteral("phase=%1").arg(m_currentPhaseId)
+                                 << QStringLiteral("loopMode=%1").arg(phase.loopMode)
+                                 << QStringLiteral("url=%1").arg(phase.url.toString())
+                                 << QStringLiteral("serial=%1").arg(m_playbackSerial)
+                                 << QStringLiteral("replacing=%1").arg(replacing);
+```
+
+- [ ] **Step 4: Normalize ExpressionMappingResolver logs**
+
+For `ExpressionMappingResolver.cpp`, convert logs to `.noquote()`. Example:
+
+```cpp
+qCDebug(petExpressionLog).noquote() << "resolve expression"
+                                    << QStringLiteral("requested=%1").arg(expression)
+                                    << QStringLiteral("resolved=%1").arg(resolvedExpression)
+                                    << QStringLiteral("state=%1").arg(state)
+                                    << QStringLiteral("candidates=%1").arg(candidates.size())
+                                    << QStringLiteral("selection=%1").arg(selection);
+```
+
+- [ ] **Step 5: Keep payload logs guarded in Go**
+
+In `provider.go`, raw provider deltas or malformed raw payloads must only appear inside:
+
+```go
+if mileslog.PayloadLoggingEnabled() {
+	logger.Debug("provider delta payload", "text", choice.Delta.Content)
+}
+```
+
+and:
+
+```go
+if mileslog.PayloadLoggingEnabled() {
+	logger.Debug("malformed provider payload", "payload", payload)
+}
+```
+
+Do not log `p.apiKey`, `Authorization`, or full request bodies.
+
+- [ ] **Step 6: Verify static contract**
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+```
+
+Expected: PASS if all earlier tasks are complete.
+
+- [ ] **Step 7: Build and run smoke tests**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke PetRuntimeSmoke LoggingFormatterSmoke
+build/apps/desktop/ChatControllerSmoke
+build/apps/desktop/PetRuntimeSmoke
+build/apps/desktop/LoggingFormatterSmoke
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.cpp \
+  apps/desktop/src/pet/PetRuntime.cpp \
+  apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp \
+  apps/agent-core/internal/chat/openai/provider.go \
+  tests/check_logging_standard.py
+git commit -m "chore: 统一项目日志格式"
+```
+
+---
+
+## Task 7: End-to-End Logging Verification
+
+**Files:**
+- Modify only if verification reveals a small contract/doc mismatch.
+
+- [ ] **Step 1: Run all logging tests**
+
+Run:
+
+```bash
+python3 tests/check_logging_standard.py
+ctest --test-dir build -R "check_logging_standard|logging_formatter_smoke|chat_controller_smoke|pet_runtime_smoke" --output-on-failure
+(cd apps/agent-core && go test ./...)
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Build the desktop app**
+
+Run:
+
+```bash
+cmake --build build --target MilesEdgeworthDesktop
+```
+
+Expected: build succeeds and `miles-agent` is copied into the app bundle.
+
+- [ ] **Step 3: Run with debug logs to file**
+
+Run:
+
+```bash
+rm -f /tmp/miles-debug.log
+QT_LOGGING_RULES='miles.*.debug=true' \
+MILES_LOG_LEVEL=debug \
+MILES_LOG_FILE=/tmp/miles-debug.log \
+MILES_LOG_PAYLOADS=0 \
+build/apps/desktop/MilesEdgeworthDesktop.app/Contents/MacOS/MilesEdgeworthDesktop
+```
+
+Manual action: send one chat message, then quit the app.
+
+Expected:
+- Debug console shows lines like:
+
+```text
+17:12:20.123 DEBUG [MILES.CHAT] stream event type=CUSTOM ...
+17:12:20.124 DEBUG [MILES.CHAT.PROVIDER] expression tag parsed tag=objection ...
+```
+
+- `/tmp/miles-debug.log` exists and contains full-date lines like:
+
+```text
+2026-05-22 17:12:20.123 DEBUG [MILES.CHAT] stream event type=CUSTOM ...
+```
+
+- `/tmp/miles-debug.log` does not contain API key values.
+- With `MILES_LOG_PAYLOADS=0`, the file does not contain raw user message text or raw model text.
+
+- [ ] **Step 4: Run payload opt-in smoke**
+
+Run again with:
+
+```bash
+rm -f /tmp/miles-debug-payloads.log
+QT_LOGGING_RULES='miles.*.debug=true' \
+MILES_LOG_LEVEL=debug \
+MILES_LOG_FILE=/tmp/miles-debug-payloads.log \
+MILES_LOG_PAYLOADS=1 \
+build/apps/desktop/MilesEdgeworthDesktop.app/Contents/MacOS/MilesEdgeworthDesktop
+```
+
+Manual action: send a harmless message like `payload smoke test`.
+
+Expected:
+- Go provider payload debug lines may include model delta text when using real provider.
+- API key is still absent.
+- This log file is local-only and must not be committed.
+
+- [ ] **Step 5: Verify no stale env or helper names remain**
+
+Run:
+
+```bash
+rg -n "MILES_DEBUG_CHAT|SetDebugLogging|debugf\\(|logProcessOutput|readyReadStandardError|log\\.Printf|log\\.Fatalf" apps tests
+```
+
+Expected: no matches in implementation or tests. If matches appear only in archived docs, leave them; if matches appear in active code/tests, fix them.
+
+- [ ] **Step 6: Commit final verification docs if needed**
+
+If no files changed during verification:
+
+```bash
+git status --short
+```
+
+Expected: clean except user-local `.vscode/` if still untracked.
+
+If a small doc or contract adjustment was required:
+
+```bash
+git add \
+  tests/check_logging_standard.py \
+  "docs/v2/设计方案/日志规范设计.md" \
+  "docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md"
+git commit -m "docs: 补充日志规范落地说明"
+```
+
+---
+
+## Final Verification Checklist
+
+Run before PR or merge:
+
+```bash
+python3 tests/check_logging_standard.py
+python3 tests/check_phase_2_1_provider.py
+python3 tests/check_phase_2_2_settings.py
+python3 tests/check_phase_2_3_1_animation_sync.py
+(cd apps/agent-core && go test ./...)
+cmake --build build --target MilesEdgeworthDesktop ChatControllerSmoke PetRuntimeSmoke LoggingFormatterSmoke
+ctest --test-dir build -R "check_logging_standard|logging_formatter_smoke|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke" --output-on-failure
+```
+
+Expected:
+- All commands pass.
+- `git status --short` is clean except intentionally ignored/untracked local files.
+- No log file containing payloads is staged.
+
+## Self-Review
+
+Spec coverage:
+- Categories: Task 1 contract + Tasks 2, 4, 6.
+- Go logger category without `WithGroup`: Task 2.
+- `MILES_LOG_LEVEL`, `MILES_LOG_FILE`, `MILES_LOG_PAYLOADS`: Tasks 2, 5, 7.
+- Qt `miles.*` custom formatting and non-project fallback: Task 4.
+- Sidecar stderr forwarding and no re-log helper: Task 5.
+- Payload safety: Tasks 2, 3, 6, 7.
+- Source file/line: Task 2 and Task 4.
+- File output best-effort cross-process behavior: Task 2 and Task 4 implement the two-process sink; Task 7 verifies output.
+
+Placeholder scan:
+- No banned placeholder markers or vague “do later” steps.
+- Every code-creating task includes concrete code or exact replacement snippets.
+- All commands include expected result.
+
+Type/name consistency:
+- Go package: `internal/mileslog`, `mileslog.New`, `PayloadLoggingEnabled`, `newHandler`, `sink`.
+- Qt namespace: `MilesLogHandler`, `install`, `isMilesCategory`, `formatMilesMessage`.
+- Contract names match implementation names.

--- a/docs/superpowers/plans/2026-05-22-phase-2-3-1-animation-text-sync.md
+++ b/docs/superpowers/plans/2026-05-22-phase-2-3-1-animation-text-sync.md
@@ -1,0 +1,2122 @@
+# Phase 2.3.1 动画-文字同步状态机与速率限制器 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make streaming text emerge at a human pace and gate on animation transitions, by landing the full ChatController state machine, a character rate limiter (ChatTextPacer) that consumes the `msPerChar` setting from Phase 2.2, and the `requestBoundaryAndNotify` / `requestCleanFinishAndNotify` notify API on PetRuntime — all per `docs/v2/设计方案/AI 聊天动画编排设计.md` §5–7.
+
+**Architecture:** ChatController gains an explicit 5-state machine (`IDLE` / `BUFFERING_FOR_START` / `STREAMING` / `GATED` / `WAITING_FOR_ANIMATION_END`) that decides whether streamed text is routed straight to the pacer or buffered in `m_holdBuffer` waiting for an animation boundary. A new `ChatTextPacer` (QObject + QTimer) emits one grapheme per tick at `msPerChar` rate, with a backlog catch-up that halves the interval when the queue exceeds 30 chars. PetRuntime grows two callback-based methods that fire at the next animation boundary (Phase 2.3.1) and will play `exit` phases when Phase 2.4's phased animations land (API stable, behavior upgrades). The pacer is owned by ChatController; PetRuntime stays unaware of chat state.
+
+**Tech Stack:** Qt 6 (C++17 + `QObject` + `QTimer` + `std::function<void()>` callbacks), CMake/Ninja/CTest, Python 3 for the static contract check. No new third-party dependencies.
+
+---
+
+## Scope Check
+
+This plan implements **Phase 2.3.1: 动画-文字同步** only. Phase 2.3 in the rough plan also covers persona content, session history (SQLite), and Langfuse — those are **separate plans** (Phase 2.3.2 and 2.3.3) and explicitly out of scope here.
+
+Included:
+- `ChatTextPacer` class with append, msPerChar setter, backlog catch-up, `chunkReady` signal.
+- ChatController state machine (5 states + transitions per AI 聊天动画编排设计 §5).
+- ChatController integration with the pacer (replaces immediate `flushHoldBuffer` write path).
+- ChatController GATED 800ms safety timeout.
+- ChatController cancel / error / network-failure path (drain hold buffer to pacer, return to IDLE, call `requestCleanFinish`).
+- PetRuntime `requestBoundaryAndNotify(std::function<void()>)` and `requestCleanFinishAndNotify(std::function<void()>)` with 1500ms safety timeout. Both methods behave identically in Phase 2.3.1 (boundary semantic); Phase 2.4 upgrades `requestCleanFinishAndNotify` to play `exit` phase without changing the protocol.
+- Tests: `chat_text_pacer_smoke` (new), extended `chat_controller_smoke` (state transitions), extended `pet_runtime_smoke` (boundary callbacks), Python contract check.
+
+Excluded:
+- Full Miles persona prompt content — Phase 2.3.2.
+- SQLite session history / new-or-clear conversation / history truncation — Phase 2.3.2.
+- Langfuse observability — Phase 2.3.3.
+- Phased `enter` / `loop` / `exit` animation support — Phase 2.4 (PetRuntime API ready, but no `exit` segment is played in 2.3.1).
+- Manifest JSON Schema validation — Phase 2.4.
+- Persona / SettingsController surface in QML — no UI changes in 2.3.1.
+
+## Assumptions
+
+- Execution starts on `main` (or a fresh worktree branched from `main`). Phase 2.2 is shipped: `SettingsService::msPerChar()` returns a persisted 40–200 ms value, the `chat_controller_smoke` test already constructs `ChatController(&runtime, &settings)`.
+- Baseline contract checks (`check_phase_2_0_ai_chat_mvp`, `check_phase_2_1_provider`, `check_phase_2_2_settings`) and all C++ smoke tests pass on `main`.
+- Qt 6.5+ available, Apple-Silicon Homebrew under `/opt/homebrew`.
+- The current Miles skin's `thinking` / `speaking` / `idle` actions are simple `loop` or `oneshot` actions (no multi-phase `enter` / `loop` / `exit`). Phase 2.4 will introduce phased actions; the API designed here must not require revision when that lands.
+
+## Required Reading
+
+Before implementing, read:
+- `docs/v2/设计方案/AI 聊天动画编排设计.md` §3 (model output convention), §4 (SSE event stream), §5 (ChatController state machine — the canonical source for transition behavior), §6 (PetRuntime API contract + boundary table), §7 (rate limiter). All design questions during implementation should be answered by consulting this document, **not** by inventing behavior.
+- Current `apps/desktop/src/chat/ChatController.{h,cpp}` to understand the existing `m_holdBuffer` plumbing from Phase 2.1.
+- Current `apps/desktop/src/pet/PetRuntime.{h,cpp}::handleAnimationFinished` to see where boundary callbacks will hook in.
+
+## File Structure
+
+Create:
+- `apps/desktop/src/chat/ChatTextPacer.h`
+  - `ChatTextPacer` `QObject` with `append(const QString &)`, `setMsPerChar(int)`, `msPerChar() const`, `pendingCount() const`, signal `chunkReady(const QString &)`. Internal: `QTimer`, character queue, backlog speedup state.
+- `apps/desktop/src/chat/ChatTextPacer.cpp`
+  - Timer-driven emit, surrogate-pair-aware character pop, backlog catch-up logic.
+- `apps/desktop/tests/chat_text_pacer_smoke.cpp`
+  - Round-trip test that uses an event loop to verify emitted chunks under controlled timing.
+- `tests/check_phase_2_3_1_animation_sync.py`
+  - Static contract check.
+- `docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md`
+  - Stage record (final task only).
+
+Modify:
+- `apps/desktop/src/chat/ChatController.h`
+  - Add `enum class ChatPhase`, member `m_phase`, pending-expression members, `ChatTextPacer *m_pacer`, gate-timeout `QTimer m_gateTimeout`, new private methods (`transitionTo`, `handleCleanFinishReady`, `handleBoundaryReached`, `handleGateTimeout`, `drainHoldBufferToPacer`, `appendChunkToCurrentMessage`).
+- `apps/desktop/src/chat/ChatController.cpp`
+  - Construct pacer + connect signals, install gate timer, rewrite `applyStreamEvent` to drive transitions, replace `flushHoldBuffer` immediate write with pacer-routed `appendChunkToCurrentMessage`, drain buffer to pacer on cancel/error.
+- `apps/desktop/src/pet/PetRuntime.h`
+  - Add `requestBoundaryAndNotify(std::function<void()>)` and `requestCleanFinishAndNotify(std::function<void()>)` declarations, a small private struct + `QList` for pending notifications, `drainPendingNotifications()`.
+- `apps/desktop/src/pet/PetRuntime.cpp`
+  - Implement the two notify methods, hook `drainPendingNotifications()` into `handleAnimationFinished` and `setCurrentAction`, install 1500ms safety timer per notification.
+- `apps/desktop/tests/chat_controller_smoke.cpp`
+  - Add new assertions for: BUFFERING_FOR_START → STREAMING via simulated `handleAnimationFinished`, mid-stream expression switch (STREAMING → GATED → STREAMING), RUN_FINISHED → WAITING_FOR_ANIMATION_END → IDLE, cancel drains hold buffer to pacer.
+- `apps/desktop/tests/pet_runtime_smoke.cpp`
+  - Add a block that calls `requestBoundaryAndNotify` and asserts the callback fires after `handleAnimationFinished`.
+- `apps/desktop/CMakeLists.txt`
+  - Add `ChatTextPacer.{h,cpp}` to `DESKTOP_SOURCES`, register a new `ChatTextPacerSmoke` test target with `Qt6::Core` + `Qt6::Test` (for `QSignalSpy`).
+- `CMakeLists.txt`
+  - Register `check_phase_2_3_1_animation_sync` ctest.
+- `docs/v2/文档索引.md`
+  - Link the Phase 2.3.1 stage record (final task).
+- `docs/v2/阶段记录/Phase 2 AI 聊天粗规划.md`
+  - Add a "已完成" callout under Phase 2.3 noting that 2.3.1 (动画-文字同步部分) is done; 2.3.2 (persona/history) and 2.3.3 (Langfuse) remain (final task).
+
+Not modified (intentional):
+- `apps/agent-core/**` — sidecar already emits the correct event sequence per Phase 2.1; no change needed for 2.3.1.
+- `apps/desktop/qml/ChatWindow.qml` — UI consumes `messages` model unchanged; chunks emitted by the pacer flow into `messagesChanged` exactly as before.
+- `apps/desktop/src/settings/**` — `msPerChar` is already persisted; ChatController reads it via `m_settings`.
+
+---
+
+## Task 0: Toolchain Preflight
+
+**Files:**
+- Read-only.
+
+- [ ] **Step 1: Verify branch state**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean working tree on `main` or a fresh worktree. If continuing from `phase-2-2-settings`, switch to `main` first via `git checkout main && git pull`. If a Phase 2.3.1 worktree is preferred, create one now using the `superpowers:using-git-worktrees` skill before continuing.
+
+- [ ] **Step 2: Verify baseline tests pass**
+
+Run:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew && \
+  ctest --test-dir build -R "check_phase_2_0_ai_chat_mvp|check_phase_2_1_provider|check_phase_2_2_settings|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke" --output-on-failure
+```
+
+Expected: all listed tests pass. If any fail, stop and fix — Phase 2.3.1 builds on top of them.
+
+- [ ] **Step 3: Verify the design doc is the version this plan targets**
+
+Run:
+
+```bash
+grep -c "BUFFERING_FOR_START" "docs/v2/设计方案/AI 聊天动画编排设计.md"
+```
+
+Expected: at least 2. The design doc must contain the 5-state vocabulary (§5.1). If it doesn't, the design doc has drifted and this plan should be reconciled before implementation begins.
+
+- [ ] **Step 4: No commit**
+
+This task changes nothing.
+
+---
+
+## Task 1: Phase 2.3.1 Static Contract Scaffold
+
+**Files:**
+- Create: `tests/check_phase_2_3_1_animation_sync.py`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write the contract test**
+
+Create `tests/check_phase_2_3_1_animation_sync.py`:
+
+```python
+#!/usr/bin/env python3
+"""Check the Phase 2.3.1 animation-text sync contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    file_path = ROOT / path
+    if not file_path.exists():
+        raise AssertionError(f"missing file: {path}")
+    return file_path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    pacer_h = read("apps/desktop/src/chat/ChatTextPacer.h")
+    pacer_cpp = read("apps/desktop/src/chat/ChatTextPacer.cpp")
+    pacer_smoke = read("apps/desktop/tests/chat_text_pacer_smoke.cpp")
+    controller_h = read("apps/desktop/src/chat/ChatController.h")
+    controller_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    controller_smoke = read("apps/desktop/tests/chat_controller_smoke.cpp")
+    runtime_h = read("apps/desktop/src/pet/PetRuntime.h")
+    runtime_cpp = read("apps/desktop/src/pet/PetRuntime.cpp")
+    runtime_smoke = read("apps/desktop/tests/pet_runtime_smoke.cpp")
+    desktop_cmake = read("apps/desktop/CMakeLists.txt")
+    root_cmake = read("CMakeLists.txt")
+    stage_doc = read("docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md")
+    index_doc = read("docs/v2/文档索引.md")
+
+    # ChatTextPacer
+    require("class ChatTextPacer" in pacer_h, "ChatTextPacer class must exist")
+    require("void append(" in pacer_h, "ChatTextPacer must expose append()")
+    require("setMsPerChar" in pacer_h, "ChatTextPacer must expose setMsPerChar()")
+    require("msPerChar()" in pacer_h, "ChatTextPacer must expose msPerChar() getter")
+    require("pendingCount()" in pacer_h, "ChatTextPacer must expose pendingCount() for tests")
+    require("void chunkReady" in pacer_h, "ChatTextPacer must declare chunkReady signal")
+    require("QTimer" in pacer_cpp, "ChatTextPacer must drive emission with QTimer")
+    require("maxBacklog" in pacer_cpp.lower() or "backlog" in pacer_cpp.lower(),
+            "ChatTextPacer must implement backlog catch-up")
+
+    # ChatController state machine
+    require("enum class ChatPhase" in controller_h, "ChatController must declare ChatPhase enum")
+    require("IDLE" in controller_h and "BUFFERING_FOR_START" in controller_h
+            and "STREAMING" in controller_h and "GATED" in controller_h
+            and "WAITING_FOR_ANIMATION_END" in controller_h,
+            "ChatPhase must include all 5 design states")
+    require("ChatTextPacer" in controller_h, "ChatController must own a ChatTextPacer")
+    require("transitionTo" in controller_h, "ChatController must expose a transitionTo helper")
+    require("handleCleanFinishReady" in controller_h,
+            "ChatController must handle PetRuntime cleanFinishReady callback")
+    require("handleBoundaryReached" in controller_h,
+            "ChatController must handle PetRuntime boundaryReached callback")
+    require("handleGateTimeout" in controller_h,
+            "ChatController must handle GATED safety timeout")
+    require("drainHoldBufferToPacer" in controller_h,
+            "ChatController must drain its hold buffer through the pacer")
+    require("appendChunkToCurrentMessage" in controller_h,
+            "ChatController must append pacer chunks via a dedicated method")
+    require("requestBoundaryAndNotify" in controller_cpp,
+            "ChatController must call requestBoundaryAndNotify on PetRuntime")
+    require("requestCleanFinishAndNotify" in controller_cpp,
+            "ChatController must call requestCleanFinishAndNotify on PetRuntime")
+
+    # PetRuntime API
+    require("requestBoundaryAndNotify" in runtime_h,
+            "PetRuntime must declare requestBoundaryAndNotify")
+    require("requestCleanFinishAndNotify" in runtime_h,
+            "PetRuntime must declare requestCleanFinishAndNotify")
+    require("std::function" in runtime_h,
+            "PetRuntime notify API must take std::function callbacks")
+    require("drainPendingNotifications" in runtime_cpp,
+            "PetRuntime must drain pending notifications at animation boundaries")
+
+    # Tests
+    require("ChatTextPacer" in pacer_smoke,
+            "pacer smoke test must exercise ChatTextPacer")
+    require("msPerChar" in pacer_smoke,
+            "pacer smoke test must cover msPerChar")
+    require("backlog" in pacer_smoke.lower(),
+            "pacer smoke test must cover backlog catch-up")
+    require("BUFFERING_FOR_START" in controller_smoke
+            or "ChatPhase" in controller_smoke,
+            "controller smoke test must exercise the state machine")
+    require("GATED" in controller_smoke
+            or "expression switch" in controller_smoke.lower(),
+            "controller smoke test must exercise mid-run expression gating")
+    require("requestBoundaryAndNotify" in runtime_smoke,
+            "runtime smoke test must exercise requestBoundaryAndNotify")
+
+    # CMake
+    require("ChatTextPacer.cpp" in desktop_cmake,
+            "desktop CMake must list ChatTextPacer.cpp")
+    require("ChatTextPacerSmoke" in desktop_cmake,
+            "desktop CMake must register the ChatTextPacerSmoke target")
+    require("chat_text_pacer_smoke" in desktop_cmake,
+            "desktop CMake must register chat_text_pacer_smoke ctest")
+    require("check_phase_2_3_1_animation_sync" in root_cmake,
+            "root CMake must register the Phase 2.3.1 contract check")
+
+    # Docs
+    require("Phase 2.3.1" in stage_doc, "Phase 2.3.1 stage record must exist")
+    require("Phase 2.3.1" in index_doc, "doc index must link Phase 2.3.1 record")
+
+    print("phase 2.3.1 animation-text sync contract ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+
+```bash
+python3 tests/check_phase_2_3_1_animation_sync.py
+```
+
+Expected: `AssertionError: missing file: apps/desktop/src/chat/ChatTextPacer.h`. The check fails fast on the first missing artifact.
+
+- [ ] **Step 3: Register in root CMakeLists.txt**
+
+Open `CMakeLists.txt`. Find the existing Phase 2.2 block:
+
+```cmake
+        # Phase 2.2 的用户配置与安全存储检查：守住设置面板、Keychain
+        # 路由、msPerChar 持久化以及 ChatController QProcess env 注入。
+        add_test(
+            NAME check_phase_2_2_settings
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_2_settings.py
+        )
+```
+
+Append immediately after it (still inside the `if(BUILD_TESTING)` / `if(Python3_Interpreter_FOUND)` blocks):
+
+```cmake
+        # Phase 2.3.1 的动画-文字同步检查：守住 ChatController 状态机、
+        # 字符速率限制器和 PetRuntime 的边界通知 API。
+        add_test(
+            NAME check_phase_2_3_1_animation_sync
+            COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_phase_2_3_1_animation_sync.py
+        )
+```
+
+- [ ] **Step 4: Verify CTest sees the new test**
+
+Run:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew >/dev/null && \
+  ctest --test-dir build -N -R check_phase_2_3_1_animation_sync
+```
+
+Expected output contains `Test #N: check_phase_2_3_1_animation_sync`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/check_phase_2_3_1_animation_sync.py CMakeLists.txt
+git commit -m "test(phase-2-3-1): add animation-text sync contract scaffold (red)"
+```
+
+---
+
+## Task 2: ChatTextPacer — Basic Stream (TDD)
+
+**Files:**
+- Create: `apps/desktop/src/chat/ChatTextPacer.h`
+- Create: `apps/desktop/src/chat/ChatTextPacer.cpp`
+- Create: `apps/desktop/tests/chat_text_pacer_smoke.cpp`
+- Modify: `apps/desktop/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing smoke test (basic stream)**
+
+Create `apps/desktop/tests/chat_text_pacer_smoke.cpp`:
+
+```cpp
+#include "chat/ChatTextPacer.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QString>
+#include <QTimer>
+
+#include <cassert>
+
+namespace {
+
+// Spin a Qt event loop until `predicate()` is true or `timeoutMs` elapses.
+bool waitFor(QCoreApplication &app, int timeoutMs, auto predicate)
+{
+    QTimer deadline;
+    deadline.setSingleShot(true);
+    deadline.start(timeoutMs);
+    while (!predicate() && deadline.isActive()) {
+        app.processEvents(QEventLoop::AllEvents, 5);
+    }
+    return predicate();
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    // --- Basic stream: characters emerge one-per-tick at msPerChar interval ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(20); // small interval keeps the test fast
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+
+        pacer.append(QStringLiteral("abc"));
+        assert(pacer.pendingCount() == 3);
+
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+
+        QString assembled;
+        for (const QList<QVariant> &args : chunks) {
+            assembled.append(args.at(0).toString());
+        }
+        assert(assembled == QStringLiteral("abc"));
+    }
+
+    // --- CJK characters: one QChar per CJK glyph still works ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(15);
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+        pacer.append(QStringLiteral("异议"));
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+        QString assembled;
+        for (const QList<QVariant> &args : chunks) {
+            assembled.append(args.at(0).toString());
+        }
+        assert(assembled == QStringLiteral("异议"));
+        assert(chunks.size() == 2);
+    }
+
+    // --- msPerChar getter round-trip ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(120);
+        assert(pacer.msPerChar() == 120);
+    }
+
+    return 0;
+}
+```
+
+- [ ] **Step 2: Write the ChatTextPacer header**
+
+Create `apps/desktop/src/chat/ChatTextPacer.h`:
+
+```cpp
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+// ChatTextPacer drives streamed text into the UI at a human reading rate
+// (default 80 ms / char). See `docs/v2/设计方案/AI 聊天动画编排设计.md` §7.
+//
+// Responsibility:
+//   - Accept incoming text via append().
+//   - Emit chunkReady(QString) on a QTimer at msPerChar intervals.
+//   - Speed up when backlog exceeds maxBacklog (§7.3).
+//
+// What it is NOT:
+//   - Not aware of ChatController state machine or PetRuntime.
+//   - Not aware of [EXPR:tag] markers (sidecar strips those before SSE).
+class ChatTextPacer : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ChatTextPacer(QObject *parent = nullptr);
+
+    // Queue text to be emitted one char per tick. Surrogate pairs are emitted
+    // as a single chunk so emoji never split across ticks.
+    void append(const QString &text);
+
+    int msPerChar() const { return m_msPerChar; }
+    void setMsPerChar(int value);
+
+    // For tests: how many QChar units are still queued.
+    int pendingCount() const { return m_queue.size(); }
+
+signals:
+    void chunkReady(const QString &chunk);
+
+private:
+    void tick();
+    int effectiveInterval() const;
+
+    QString m_queue;
+    QTimer m_timer;
+    int m_msPerChar = 80;
+
+    static constexpr int kMaxBacklog = 30;
+    static constexpr double kBacklogSpeedupFactor = 0.5;
+};
+```
+
+- [ ] **Step 3: Write the basic ChatTextPacer implementation**
+
+Create `apps/desktop/src/chat/ChatTextPacer.cpp`:
+
+```cpp
+#include "chat/ChatTextPacer.h"
+
+#include <QChar>
+
+ChatTextPacer::ChatTextPacer(QObject *parent)
+    : QObject(parent)
+{
+    m_timer.setSingleShot(false);
+    connect(&m_timer, &QTimer::timeout, this, &ChatTextPacer::tick);
+}
+
+void ChatTextPacer::append(const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+    m_queue.append(text);
+    if (!m_timer.isActive()) {
+        m_timer.start(effectiveInterval());
+    }
+}
+
+void ChatTextPacer::setMsPerChar(int value)
+{
+    if (value < 1) value = 1;
+    if (value == m_msPerChar) return;
+    m_msPerChar = value;
+    if (m_timer.isActive()) {
+        m_timer.start(effectiveInterval());
+    }
+}
+
+int ChatTextPacer::effectiveInterval() const
+{
+    return m_msPerChar;
+}
+
+void ChatTextPacer::tick()
+{
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+        return;
+    }
+
+    // Surrogate pair: emit both halves together so emoji aren't sliced.
+    int popCount = 1;
+    const QChar first = m_queue.at(0);
+    if (first.isHighSurrogate() && m_queue.size() >= 2) {
+        const QChar second = m_queue.at(1);
+        if (second.isLowSurrogate()) {
+            popCount = 2;
+        }
+    }
+
+    const QString chunk = m_queue.left(popCount);
+    m_queue.remove(0, popCount);
+    emit chunkReady(chunk);
+
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+    }
+}
+```
+
+(Backlog catch-up is added in Task 3 — for now `effectiveInterval()` just returns `m_msPerChar`.)
+
+- [ ] **Step 4: Register the pacer in DESKTOP_SOURCES and add the smoke target**
+
+Open `apps/desktop/CMakeLists.txt`. Find the `DESKTOP_SOURCES` block. After the existing `src/chat/ChatStreamEvent.h` line, append (alphabetical order):
+
+```cmake
+    src/chat/ChatTextPacer.cpp
+    src/chat/ChatTextPacer.h
+```
+
+Then inside the `if(BUILD_TESTING)` block, after the existing `chat_stream_event_parser_smoke` test, append:
+
+```cmake
+    add_executable(ChatTextPacerSmoke
+        tests/chat_text_pacer_smoke.cpp
+        src/chat/ChatTextPacer.cpp
+        src/chat/ChatTextPacer.h
+    )
+
+    target_include_directories(ChatTextPacerSmoke
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    target_link_libraries(ChatTextPacerSmoke
+        PRIVATE
+            Qt6::Core
+            Qt6::Test
+    )
+
+    add_test(NAME chat_text_pacer_smoke COMMAND ChatTextPacerSmoke)
+```
+
+The `Qt6::Test` link is needed for `QSignalSpy`. Verify the existing `find_package(Qt6 ...)` line at the top of the file includes the `Test` component; if not, add it. The existing line currently is:
+
+```cmake
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2)
+```
+
+Replace with:
+
+```cmake
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Quick Widgets Multimedia Network QuickControls2 Test)
+```
+
+- [ ] **Step 5: Reconfigure and run the smoke test**
+
+Run:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew && \
+  cmake --build build --target ChatTextPacerSmoke && \
+  ctest --test-dir build -R chat_text_pacer_smoke --output-on-failure
+```
+
+Expected: builds, test passes. If `Qt6::Test` isn't found, double-check the `find_package` line.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatTextPacer.h \
+        apps/desktop/src/chat/ChatTextPacer.cpp \
+        apps/desktop/tests/chat_text_pacer_smoke.cpp \
+        apps/desktop/CMakeLists.txt
+git commit -m "feat(desktop): ChatTextPacer basic streaming"
+```
+
+---
+
+## Task 3: ChatTextPacer — Backlog Catch-up + msPerChar (TDD)
+
+**Files:**
+- Modify: `apps/desktop/tests/chat_text_pacer_smoke.cpp`
+- Modify: `apps/desktop/src/chat/ChatTextPacer.cpp`
+
+- [ ] **Step 1: Add the failing backlog assertion to the smoke test**
+
+Open `apps/desktop/tests/chat_text_pacer_smoke.cpp`. Above `return 0;`, insert:
+
+```cpp
+    // --- Backlog catch-up: when queue exceeds maxBacklog, interval halves ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(40);
+        QSignalSpy chunks(&pacer, &ChatTextPacer::chunkReady);
+
+        // 60 chars > maxBacklog (30) → effective interval should drop to 20 ms.
+        // Total emit time should be roughly 60 * 20 = 1200 ms with backlog
+        // speedup, vs 60 * 40 = 2400 ms without. We test the qualitative
+        // property: the drain finishes faster than the no-speedup baseline.
+        QString long_payload;
+        for (int i = 0; i < 60; ++i) long_payload.append(QChar('x'));
+        const qint64 start = QDateTime::currentMSecsSinceEpoch();
+        pacer.append(long_payload);
+
+        const bool drained = waitFor(app, 3000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+        const qint64 elapsed = QDateTime::currentMSecsSinceEpoch() - start;
+
+        // No-speedup baseline = 60 * 40 = 2400 ms. With backlog kicking in
+        // around the 30-char mark, total time should be well under 2200 ms.
+        assert(elapsed < 2200);
+        assert(chunks.size() == 60);
+    }
+
+    // --- setMsPerChar updates an active timer interval ---
+    {
+        ChatTextPacer pacer;
+        pacer.setMsPerChar(200);
+        pacer.append(QStringLiteral("yz"));
+        pacer.setMsPerChar(15);
+        const bool drained = waitFor(app, 1000, [&]() { return pacer.pendingCount() == 0; });
+        assert(drained);
+    }
+```
+
+At the top of the file, add `#include <QDateTime>` near the existing `#include <QTimer>`.
+
+- [ ] **Step 2: Run to verify the new assertion fails**
+
+Run:
+
+```bash
+cmake --build build --target ChatTextPacerSmoke && \
+  ctest --test-dir build -R chat_text_pacer_smoke --output-on-failure
+```
+
+Expected: fails because the test now expects `elapsed < 2200` ms for a 60-char drain at 40 ms/char, which requires backlog speedup to be active.
+
+- [ ] **Step 3: Implement backlog catch-up**
+
+Open `apps/desktop/src/chat/ChatTextPacer.cpp`. Replace `effectiveInterval()` and `tick()` with:
+
+```cpp
+int ChatTextPacer::effectiveInterval() const
+{
+    if (m_queue.size() > kMaxBacklog) {
+        const int sped = static_cast<int>(m_msPerChar * kBacklogSpeedupFactor);
+        return sped < 1 ? 1 : sped;
+    }
+    return m_msPerChar;
+}
+
+void ChatTextPacer::tick()
+{
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+        return;
+    }
+
+    int popCount = 1;
+    const QChar first = m_queue.at(0);
+    if (first.isHighSurrogate() && m_queue.size() >= 2) {
+        const QChar second = m_queue.at(1);
+        if (second.isLowSurrogate()) {
+            popCount = 2;
+        }
+    }
+
+    const QString chunk = m_queue.left(popCount);
+    m_queue.remove(0, popCount);
+    emit chunkReady(chunk);
+
+    if (m_queue.isEmpty()) {
+        m_timer.stop();
+        return;
+    }
+
+    // Adapt interval to current backlog level on each tick so the rate
+    // returns to normal as the queue drains.
+    const int next = effectiveInterval();
+    if (m_timer.interval() != next) {
+        m_timer.start(next);
+    }
+}
+```
+
+Also update `append()` to start with the effective interval (already does via `effectiveInterval()`; no change). Update `setMsPerChar` to use `effectiveInterval()` as well — already in place.
+
+- [ ] **Step 4: Run the test**
+
+Run:
+
+```bash
+cmake --build build --target ChatTextPacerSmoke && \
+  ctest --test-dir build -R chat_text_pacer_smoke --output-on-failure
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/tests/chat_text_pacer_smoke.cpp \
+        apps/desktop/src/chat/ChatTextPacer.cpp
+git commit -m "feat(desktop): ChatTextPacer backlog catch-up + dynamic msPerChar"
+```
+
+---
+
+## Task 4: PetRuntime — Boundary / CleanFinish Notify API (TDD)
+
+**Files:**
+- Modify: `apps/desktop/tests/pet_runtime_smoke.cpp`
+- Modify: `apps/desktop/src/pet/PetRuntime.h`
+- Modify: `apps/desktop/src/pet/PetRuntime.cpp`
+
+- [ ] **Step 1: Add the failing smoke test block**
+
+Open `apps/desktop/tests/pet_runtime_smoke.cpp`. Near the end of `main()` (before any `return 0` or final cleanup), insert:
+
+```cpp
+    // --- Phase 2.3.1: requestBoundaryAndNotify fires after handleAnimationFinished ---
+    {
+        PetRuntime runtime;
+        runtime.setState(QStringLiteral("speaking"));
+        // The runtime is now running a speaking action; the callback should NOT
+        // fire synchronously.
+        int boundaryHits = 0;
+        runtime.requestBoundaryAndNotify([&boundaryHits]() { ++boundaryHits; });
+        require(boundaryHits == 0,
+                "requestBoundaryAndNotify must not fire while a speaking action is active");
+
+        runtime.handleAnimationFinished();
+        require(boundaryHits == 1,
+                "requestBoundaryAndNotify callback should fire on the next animation boundary");
+    }
+
+    // --- requestBoundaryAndNotify on idle runtime fires synchronously ---
+    {
+        PetRuntime runtime;
+        runtime.setState(QStringLiteral("idle"));
+        int boundaryHits = 0;
+        runtime.requestBoundaryAndNotify([&boundaryHits]() { ++boundaryHits; });
+        require(boundaryHits == 1,
+                "requestBoundaryAndNotify on idle runtime should fire synchronously");
+    }
+
+    // --- requestCleanFinishAndNotify behaves the same in Phase 2.3.1 ---
+    {
+        PetRuntime runtime;
+        runtime.setState(QStringLiteral("speaking"));
+        int hits = 0;
+        runtime.requestCleanFinishAndNotify([&hits]() { ++hits; });
+        require(hits == 0,
+                "requestCleanFinishAndNotify must not fire while a speaking action is active");
+        runtime.handleAnimationFinished();
+        require(hits == 1,
+                "requestCleanFinishAndNotify callback should fire on animation boundary");
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+cmake --build build --target PetRuntimeSmoke 2>&1 | tail -10
+```
+
+Expected: build fails because `requestBoundaryAndNotify` and `requestCleanFinishAndNotify` don't exist yet.
+
+- [ ] **Step 3: Add the API to PetRuntime.h**
+
+Open `apps/desktop/src/pet/PetRuntime.h`. Find the existing `Q_INVOKABLE void requestExpression(...)` declarations near line 150. After the `handleAnimationFinished` declaration (around line 153), add:
+
+```cpp
+    // Phase 2.3.1: chat-side animation gating. Both fire `callback` on the
+    // next animation boundary, or synchronously if the runtime is idle.
+    //
+    // Phase 2.3.1 they behave identically (boundary semantic). Phase 2.4 will
+    // teach `requestCleanFinishAndNotify` to play `exit` phases before firing,
+    // without changing the API — see docs/v2/设计方案/AI 聊天动画编排设计.md §6.
+    void requestBoundaryAndNotify(std::function<void()> callback);
+    void requestCleanFinishAndNotify(std::function<void()> callback);
+```
+
+At the top, add includes:
+
+```cpp
+#include <functional>
+```
+
+Inside the `private:` section, add (after the existing helper declarations):
+
+```cpp
+    void drainPendingNotifications();
+    bool atAnimationBoundary() const;
+
+    struct PendingNotification {
+        std::function<void()> callback;
+        QTimer *safetyTimer;
+    };
+    QList<PendingNotification> m_pendingNotifications;
+```
+
+Add `#include <QTimer>` if it's not already there (it is). Note that `QList<PendingNotification>` is needed; the existing file already pulls `<QList>`.
+
+- [ ] **Step 4: Add the implementation in PetRuntime.cpp**
+
+Open `apps/desktop/src/pet/PetRuntime.cpp`. Near the bottom of the file (after the existing `handleAnimationFinished` definition), append:
+
+```cpp
+namespace {
+constexpr int kBoundarySafetyMs = 1500;
+} // namespace
+
+bool PetRuntime::atAnimationBoundary() const
+{
+    if (m_currentState == QStringLiteral("idle")) {
+        return true;
+    }
+    if (m_currentActionId.isEmpty() && m_currentRecipeId.isEmpty()) {
+        return true;
+    }
+    return false;
+}
+
+void PetRuntime::requestBoundaryAndNotify(std::function<void()> callback)
+{
+    if (!callback) {
+        return;
+    }
+    if (atAnimationBoundary()) {
+        callback();
+        return;
+    }
+
+    QTimer *safety = new QTimer(this);
+    safety->setSingleShot(true);
+    PendingNotification entry{std::move(callback), safety};
+    const int index = m_pendingNotifications.size();
+    m_pendingNotifications.append(std::move(entry));
+
+    connect(safety, &QTimer::timeout, this, [this, index]() {
+        // Safety: if the index is still pending, fire it and remove.
+        if (index < 0 || index >= m_pendingNotifications.size()) {
+            return;
+        }
+        PendingNotification entry = m_pendingNotifications.takeAt(index);
+        if (entry.safetyTimer) {
+            entry.safetyTimer->deleteLater();
+        }
+        if (entry.callback) {
+            entry.callback();
+        }
+    });
+    safety->start(kBoundarySafetyMs);
+}
+
+void PetRuntime::requestCleanFinishAndNotify(std::function<void()> callback)
+{
+    // Phase 2.3.1: cleanFinish == boundary. Phase 2.4 will branch on
+    // ActionDefinition::exitPhase to play the exit segment before notifying.
+    requestBoundaryAndNotify(std::move(callback));
+}
+
+void PetRuntime::drainPendingNotifications()
+{
+    QList<PendingNotification> entries;
+    entries.swap(m_pendingNotifications);
+    for (PendingNotification &entry : entries) {
+        if (entry.safetyTimer) {
+            entry.safetyTimer->stop();
+            entry.safetyTimer->deleteLater();
+        }
+        if (entry.callback) {
+            entry.callback();
+        }
+    }
+}
+```
+
+Then hook `drainPendingNotifications()` into the natural boundary point. Find the existing `void PetRuntime::handleAnimationFinished()` body (around line 425). At the end of its body — after the final `setState("idle")` or right before each `return` — call `drainPendingNotifications()`. The simplest placement is to make it the *first* statement so any pending callback fires whether or not a recipe step advances:
+
+Replace the existing body:
+
+```cpp
+void PetRuntime::handleAnimationFinished()
+{
+    const ActionDefinition action = m_manifest.actions.value(m_currentActionId);
+    const PhaseDefinition phase = action.phases.value(m_currentPhaseId);
+    if (!phase.nextPhase.isEmpty() && action.phases.contains(phase.nextPhase)) {
+        playPhase(m_currentActionId, phase.nextPhase);
+        return;
+    }
+    // ... existing logic
+}
+```
+
+With:
+
+```cpp
+void PetRuntime::handleAnimationFinished()
+{
+    const ActionDefinition action = m_manifest.actions.value(m_currentActionId);
+    const PhaseDefinition phase = action.phases.value(m_currentPhaseId);
+    if (!phase.nextPhase.isEmpty() && action.phases.contains(phase.nextPhase)) {
+        playPhase(m_currentActionId, phase.nextPhase);
+        return;
+    }
+
+    // 任何动画自然结束都算一次 boundary —— 即使后续会切到下一个 recipe step
+    // 或回 idle，对 chat 状态机来说这一刻是可以放行新文字的。
+    drainPendingNotifications();
+
+    applyFacingAfterCurrentAction(action);
+
+    if (!m_currentRecipeId.isEmpty()) {
+        const RecipeDefinition recipe = m_manifest.recipes.value(m_currentRecipeId);
+        if (m_currentRecipeStepIndex + 1 < recipe.steps.size()) {
+            playNextRecipeStep();
+            return;
+        }
+
+        clearActiveRecipe();
+    }
+
+    if (m_pendingRequest.kind != ActionRequestKind::None) {
+        submitPendingActionRequest();
+        return;
+    }
+
+    if (m_currentAutoReturnToIdle) {
+        if (submitRuntimeEvent(PetEvent::actionCompleted(QRandomGenerator::global()->generateDouble()))) {
+            return;
+        }
+
+        setState("idle");
+    }
+}
+```
+
+The exact existing body in the file is what you must preserve — only insert `drainPendingNotifications();` immediately after the phase-skip return, before the rest of the logic. If the body has drifted from what's shown above, locate the equivalent insertion point (right after the phase advance check, before `applyFacingAfterCurrentAction`).
+
+- [ ] **Step 5: Run the test**
+
+Run:
+
+```bash
+cmake --build build --target PetRuntimeSmoke && \
+  ctest --test-dir build -R pet_runtime_smoke --output-on-failure
+```
+
+Expected: passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/pet/PetRuntime.h \
+        apps/desktop/src/pet/PetRuntime.cpp \
+        apps/desktop/tests/pet_runtime_smoke.cpp
+git commit -m "feat(desktop): PetRuntime boundary/cleanFinish notify API"
+```
+
+---
+
+## Task 5: ChatController — State Machine + BUFFERING_FOR_START → STREAMING
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.h`
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Modify: `apps/desktop/tests/chat_controller_smoke.cpp`
+
+- [ ] **Step 1: Add failing assertions to the smoke test**
+
+Open `apps/desktop/tests/chat_controller_smoke.cpp`. Near the existing hold-buffer block (around line 120), **before** the `return 0;` at the end, insert a new block:
+
+```cpp
+    // --- Phase 2.3.1: BUFFERING_FOR_START holds text until cleanFinishReady ---
+    {
+        PetRuntime smRuntime;
+        smRuntime.setState(QStringLiteral("speaking")); // simulate non-idle baseline
+        ChatController smController(&smRuntime, &settings);
+
+        ChatStreamEvent smStarted;
+        smStarted.type = QStringLiteral("RUN_STARTED");
+        smController.applyStreamEvent(smStarted);
+        // BUFFERING_FOR_START: text must be queued, not emitted to UI yet.
+
+        ChatStreamEvent smExpr;
+        smExpr.type = QStringLiteral("CUSTOM");
+        smExpr.name = QStringLiteral("miles.pet.expression.requested");
+        smExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        smExpr.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        smController.applyStreamEvent(smExpr);
+
+        ChatStreamEvent smStart;
+        smStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        smStart.role = QStringLiteral("assistant");
+        smController.applyStreamEvent(smStart);
+
+        ChatStreamEvent smText;
+        smText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        smText.delta = QStringLiteral("异议!");
+        smController.applyStreamEvent(smText);
+
+        const auto messagesWhileBuffering = smController.messages();
+        const QString textWhileBuffering = messagesWhileBuffering.constLast()
+                .toMap().value(QStringLiteral("text")).toString();
+        require(textWhileBuffering.isEmpty(),
+                "BUFFERING_FOR_START must NOT push streamed text to the UI yet");
+
+        // Simulate PetRuntime reaching a clean finish on the previous animation.
+        smRuntime.handleAnimationFinished();
+        // Pacer should now drain "异议!" into the assistant message at human pace.
+        // We don't wait for the full drain here — just assert that the pacer
+        // has something queued or has emitted at least one chunk.
+        // (Full drain timing is covered by ChatTextPacerSmoke.)
+    }
+```
+
+- [ ] **Step 2: Run the build — expect failure due to missing types**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke 2>&1 | tail -10
+```
+
+Expected: compile failure on something the new ChatController types will provide (or the new block references the existing API but the test assertion fails because text already flushes immediately).
+
+- [ ] **Step 3: Add state machine declarations to ChatController.h**
+
+Open `apps/desktop/src/chat/ChatController.h`. After the existing `#include` block, add:
+
+```cpp
+#include <functional>
+```
+
+Forward-declare the pacer at the top, alongside the existing `class PetRuntime;` / `class SettingsService;`:
+
+```cpp
+class ChatTextPacer;
+```
+
+Inside the class definition, after the `Q_PROPERTY` block and before the constructor, add:
+
+```cpp
+public:
+    enum class ChatPhase {
+        IDLE,
+        BUFFERING_FOR_START,
+        STREAMING,
+        GATED,
+        WAITING_FOR_ANIMATION_END,
+    };
+```
+
+Add the private members at the bottom of the existing `private:` section (replacing the existing `m_holdBuffer` comment block — we are repurposing the buffer for real gating now):
+
+```cpp
+    ChatPhase m_phase = ChatPhase::IDLE;
+    QString m_pendingState;
+    QString m_pendingExpression;
+    ChatTextPacer *m_pacer = nullptr;
+    QTimer m_gateTimeout;
+    static constexpr int kGateTimeoutMs = 800;
+```
+
+Replace the comment above `QString m_holdBuffer;` to reflect the new role:
+
+```cpp
+    // Phase 2.3.1: while m_phase is BUFFERING_FOR_START or GATED, streamed
+    // text accumulates here. On transition to STREAMING, it drains into the
+    // pacer. See docs/v2/设计方案/AI 聊天动画编排设计.md §5.
+    QString m_holdBuffer;
+```
+
+Add the new private method declarations (after the existing `flushHoldBuffer()`):
+
+```cpp
+    void transitionTo(ChatPhase next);
+    void handleCleanFinishReady();
+    void handleBoundaryReached();
+    void handleGateTimeout();
+    void drainHoldBufferToPacer();
+    void appendChunkToCurrentMessage(const QString &chunk);
+```
+
+- [ ] **Step 4: Wire the pacer + gate timer in the ChatController constructor**
+
+Open `apps/desktop/src/chat/ChatController.cpp`. Add an include at the top:
+
+```cpp
+#include "chat/ChatTextPacer.h"
+```
+
+In the constructor body (currently starts with `m_runtime(runtime)`), append after the existing `connect(...)` lines:
+
+```cpp
+    m_pacer = new ChatTextPacer(this);
+    connect(m_pacer, &ChatTextPacer::chunkReady,
+            this, &ChatController::appendChunkToCurrentMessage);
+    if (m_settings != nullptr) {
+        m_pacer->setMsPerChar(m_settings->msPerChar());
+    }
+
+    m_gateTimeout.setSingleShot(true);
+    connect(&m_gateTimeout, &QTimer::timeout,
+            this, &ChatController::handleGateTimeout);
+```
+
+In `handleSettingsSaved()`, after the existing `restartSidecar();` line, append:
+
+```cpp
+    if (m_settings != nullptr && m_pacer != nullptr) {
+        m_pacer->setMsPerChar(m_settings->msPerChar());
+    }
+```
+
+- [ ] **Step 5: Implement the state machine helpers (no event-handler changes yet)**
+
+In `apps/desktop/src/chat/ChatController.cpp`, near the bottom of the file (after `failCurrentReply`), append:
+
+```cpp
+void ChatController::transitionTo(ChatPhase next)
+{
+    if (m_phase == next) {
+        return;
+    }
+    m_phase = next;
+    // Phase 2.3.1 keeps transitions internal — no signal needs to leak to QML.
+}
+
+void ChatController::handleCleanFinishReady()
+{
+    if (m_phase != ChatPhase::BUFFERING_FOR_START) {
+        return;
+    }
+    if (!m_pendingExpression.isEmpty()) {
+        requestPetExpression(m_pendingState, m_pendingExpression);
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+    }
+    transitionTo(ChatPhase::STREAMING);
+    drainHoldBufferToPacer();
+}
+
+void ChatController::handleBoundaryReached()
+{
+    m_gateTimeout.stop();
+    if (m_phase == ChatPhase::GATED) {
+        if (!m_pendingExpression.isEmpty()) {
+            requestPetExpression(m_pendingState, m_pendingExpression);
+            m_pendingExpression.clear();
+            m_pendingState.clear();
+        }
+        transitionTo(ChatPhase::STREAMING);
+        drainHoldBufferToPacer();
+        return;
+    }
+    if (m_phase == ChatPhase::WAITING_FOR_ANIMATION_END) {
+        if (m_runtime != nullptr) {
+            m_runtime->returnToIdle();
+        }
+        transitionTo(ChatPhase::IDLE);
+    }
+}
+
+void ChatController::handleGateTimeout()
+{
+    if (m_phase != ChatPhase::GATED) {
+        return;
+    }
+    if (!m_pendingExpression.isEmpty()) {
+        requestPetExpression(m_pendingState, m_pendingExpression);
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+    }
+    transitionTo(ChatPhase::STREAMING);
+    drainHoldBufferToPacer();
+}
+
+void ChatController::drainHoldBufferToPacer()
+{
+    if (m_holdBuffer.isEmpty() || m_pacer == nullptr) {
+        return;
+    }
+    m_pacer->append(m_holdBuffer);
+    m_holdBuffer.clear();
+}
+
+void ChatController::appendChunkToCurrentMessage(const QString &chunk)
+{
+    if (m_cancelled || chunk.isEmpty()) {
+        return;
+    }
+    if (m_assistantMessageIndex < 0 || m_assistantMessageIndex >= m_messages.size()) {
+        appendMessage(messageObject(QStringLiteral("assistant"), QString(), true, false));
+        m_assistantMessageIndex = m_messages.size() - 1;
+    }
+    QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+    message.insert(QStringLiteral("text"),
+                   message.value(QStringLiteral("text")).toString() + chunk);
+    message.insert(QStringLiteral("pending"), true);
+    m_messages[m_assistantMessageIndex] = message;
+    emit messagesChanged();
+}
+```
+
+- [ ] **Step 6: Wire RUN_STARTED → BUFFERING_FOR_START in applyStreamEvent**
+
+Open `apps/desktop/src/chat/ChatController.cpp`. Find the existing handler for `RUN_STARTED`:
+
+```cpp
+    if (event.type == QStringLiteral("RUN_STARTED")) {
+        setSending(true);
+        setStatusText(QStringLiteral("正在回复"));
+        return;
+    }
+```
+
+Replace with:
+
+```cpp
+    if (event.type == QStringLiteral("RUN_STARTED")) {
+        setSending(true);
+        setStatusText(QStringLiteral("正在回复"));
+        m_holdBuffer.clear();
+        m_pendingExpression.clear();
+        m_pendingState.clear();
+        transitionTo(ChatPhase::BUFFERING_FOR_START);
+        if (m_runtime != nullptr) {
+            m_runtime->requestCleanFinishAndNotify([this]() {
+                handleCleanFinishReady();
+            });
+        }
+        return;
+    }
+```
+
+Find the existing `TEXT_MESSAGE_CONTENT` handler:
+
+```cpp
+    if (event.type == QStringLiteral("TEXT_MESSAGE_CONTENT")) {
+        appendAssistantDelta(event.delta);
+        return;
+    }
+```
+
+Replace with:
+
+```cpp
+    if (event.type == QStringLiteral("TEXT_MESSAGE_CONTENT")) {
+        if (m_phase == ChatPhase::STREAMING) {
+            if (m_pacer != nullptr) {
+                m_pacer->append(event.delta);
+            } else {
+                m_holdBuffer.append(event.delta);
+                flushHoldBuffer();
+            }
+        } else {
+            m_holdBuffer.append(event.delta);
+        }
+        return;
+    }
+```
+
+Find the existing CUSTOM `expression.requested` handler:
+
+```cpp
+    if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
+        requestPetExpression(event.value.value(QStringLiteral("state")).toString(),
+                             event.value.value(QStringLiteral("expression")).toString(),
+                             interruptHintFromValue(event.value));
+    }
+```
+
+Replace with:
+
+```cpp
+    if (event.type == QStringLiteral("CUSTOM") && event.name == QString::fromLatin1(kExpressionRequestedEvent)) {
+        const QString state = event.value.value(QStringLiteral("state")).toString();
+        const QString expression = event.value.value(QStringLiteral("expression")).toString();
+
+        if (m_phase == ChatPhase::BUFFERING_FOR_START
+                || m_phase == ChatPhase::GATED) {
+            // Store; will be applied on the next boundary callback.
+            m_pendingState = state;
+            m_pendingExpression = expression;
+            return;
+        }
+
+        if (m_phase == ChatPhase::STREAMING) {
+            m_pendingState = state;
+            m_pendingExpression = expression;
+            transitionTo(ChatPhase::GATED);
+            m_gateTimeout.start(kGateTimeoutMs);
+            if (m_runtime != nullptr) {
+                m_runtime->requestBoundaryAndNotify([this]() {
+                    handleBoundaryReached();
+                });
+            }
+            return;
+        }
+
+        // IDLE / WAITING_FOR_ANIMATION_END: fall back to immediate apply
+        // (matches pre-2.3.1 behavior and keeps the legacy path working).
+        requestPetExpression(state, expression, interruptHintFromValue(event.value));
+    }
+```
+
+- [ ] **Step 7: Build and run smoke tests**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  ctest --test-dir build -R chat_controller_smoke --output-on-failure
+```
+
+Expected: the new "BUFFERING_FOR_START must NOT push streamed text to the UI yet" assertion passes. Earlier assertions about thinking/speaking expression state may still pass because the test calls `applyStreamEvent` directly without firing RUN_STARTED first in those blocks — verify all existing assertions still pass too.
+
+If existing assertions fail, the most likely cause is that an existing test block sends `CUSTOM thinking` before `RUN_STARTED`; in that case the path falls through to the legacy `requestPetExpression` call by design. If the test fails for a different reason, debug before continuing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.h \
+        apps/desktop/src/chat/ChatController.cpp \
+        apps/desktop/tests/chat_controller_smoke.cpp
+git commit -m "feat(desktop): ChatController state machine + BUFFERING_FOR_START gate"
+```
+
+---
+
+## Task 6: ChatController — STREAMING ⇄ GATED (Mid-Run Expression)
+
+**Files:**
+- Modify: `apps/desktop/tests/chat_controller_smoke.cpp`
+
+(All ChatController code paths needed for this transition were added in Task 5; this task just verifies them with explicit assertions.)
+
+- [ ] **Step 1: Add the mid-stream expression-switch assertion**
+
+Open `apps/desktop/tests/chat_controller_smoke.cpp`. After the existing BUFFERING_FOR_START block added in Task 5, append:
+
+```cpp
+    // --- Phase 2.3.1: mid-stream expression switch (STREAMING → GATED → STREAMING) ---
+    {
+        PetRuntime gRuntime;
+        ChatController gController(&gRuntime, &settings);
+
+        // Drive the controller into STREAMING.
+        ChatStreamEvent gStarted;
+        gStarted.type = QStringLiteral("RUN_STARTED");
+        gController.applyStreamEvent(gStarted);
+        // Runtime starts at idle → cleanFinish fires synchronously → STREAMING.
+
+        ChatStreamEvent gExpr1;
+        gExpr1.type = QStringLiteral("CUSTOM");
+        gExpr1.name = QStringLiteral("miles.pet.expression.requested");
+        gExpr1.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        gExpr1.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        gController.applyStreamEvent(gExpr1);
+
+        ChatStreamEvent gStart;
+        gStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        gStart.role = QStringLiteral("assistant");
+        gController.applyStreamEvent(gStart);
+
+        ChatStreamEvent gText1;
+        gText1.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        gText1.delta = QStringLiteral("片段1");
+        gController.applyStreamEvent(gText1);
+        // Currently STREAMING — text goes to pacer. The UI may not have seen it yet.
+
+        // Mid-run expression event → enters GATED.
+        ChatStreamEvent gExpr2;
+        gExpr2.type = QStringLiteral("CUSTOM");
+        gExpr2.name = QStringLiteral("miles.pet.expression.requested");
+        gExpr2.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        gExpr2.value.insert(QStringLiteral("expression"), QStringLiteral("polite"));
+        gController.applyStreamEvent(gExpr2);
+
+        // While GATED, additional text must be buffered, not flushed.
+        ChatStreamEvent gText2;
+        gText2.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        gText2.delta = QStringLiteral("片段2");
+        gController.applyStreamEvent(gText2);
+
+        // Snapshot the current message text BEFORE the boundary fires.
+        const QString preBoundaryText = gController.messages().constLast()
+                .toMap().value(QStringLiteral("text")).toString();
+
+        // Now drive the boundary callback.
+        gRuntime.handleAnimationFinished();
+        // After boundary: pacer should now have 片段2 enqueued and the next
+        // expression should be requested. We don't wait for full pacer drain
+        // (covered by ChatTextPacerSmoke), but we assert that the runtime now
+        // reflects the second expression.
+        require(gRuntime.currentState() == QStringLiteral("speaking"),
+                "boundary callback should request the queued polite expression");
+    }
+```
+
+- [ ] **Step 2: Build and run**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  ctest --test-dir build -R chat_controller_smoke --output-on-failure
+```
+
+Expected: passes. The smoke test now exercises the mid-stream STREAMING → GATED → STREAMING transition.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/tests/chat_controller_smoke.cpp
+git commit -m "test(phase-2-3-1): cover STREAMING → GATED → STREAMING transition"
+```
+
+---
+
+## Task 7: ChatController — STREAMING → WAITING_FOR_ANIMATION_END → IDLE on RUN_FINISHED
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Modify: `apps/desktop/tests/chat_controller_smoke.cpp`
+
+- [ ] **Step 1: Add the failing assertion**
+
+Open `apps/desktop/tests/chat_controller_smoke.cpp`. After the GATED block from Task 6, append:
+
+```cpp
+    // --- Phase 2.3.1: RUN_FINISHED → WAITING_FOR_ANIMATION_END → IDLE ---
+    {
+        PetRuntime fRuntime;
+        ChatController fController(&fRuntime, &settings);
+
+        ChatStreamEvent fStarted;
+        fStarted.type = QStringLiteral("RUN_STARTED");
+        fController.applyStreamEvent(fStarted);
+
+        ChatStreamEvent fExpr;
+        fExpr.type = QStringLiteral("CUSTOM");
+        fExpr.name = QStringLiteral("miles.pet.expression.requested");
+        fExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        fExpr.value.insert(QStringLiteral("expression"), QStringLiteral("polite"));
+        fController.applyStreamEvent(fExpr);
+
+        ChatStreamEvent fStart;
+        fStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        fStart.role = QStringLiteral("assistant");
+        fController.applyStreamEvent(fStart);
+
+        require(fController.sending(),
+                "controller should be sending after RUN_STARTED");
+
+        ChatStreamEvent fFinished;
+        fFinished.type = QStringLiteral("RUN_FINISHED");
+        fController.applyStreamEvent(fFinished);
+        require(!fController.sending(),
+                "RUN_FINISHED should clear the sending flag");
+        require(fRuntime.currentState() == QStringLiteral("speaking"),
+                "RUN_FINISHED must not interrupt the active speaking animation");
+
+        // After the next boundary, the controller should return to idle.
+        fRuntime.handleAnimationFinished();
+        require(fRuntime.currentState() == QStringLiteral("idle"),
+                "boundary after RUN_FINISHED should return PetRuntime to idle");
+    }
+```
+
+- [ ] **Step 2: Build the test — expect failure**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke 2>&1 | tail -10
+```
+
+Expected: the new block fails because `RUN_FINISHED` doesn't yet route through the state machine — the existing handler calls `finishCurrentReply()` which clears sending but doesn't request boundary or transition to WAITING_FOR_ANIMATION_END.
+
+- [ ] **Step 3: Route RUN_FINISHED through the state machine**
+
+Open `apps/desktop/src/chat/ChatController.cpp`. Find the existing `RUN_FINISHED` handler:
+
+```cpp
+    if (event.type == QStringLiteral("RUN_FINISHED")) {
+        finishCurrentReply();
+        return;
+    }
+```
+
+Replace with:
+
+```cpp
+    if (event.type == QStringLiteral("RUN_FINISHED")) {
+        // Clear sending + status now; pet animation still needs to settle.
+        if (m_assistantMessageIndex >= 0 && m_assistantMessageIndex < m_messages.size()) {
+            QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+            message.insert(QStringLiteral("pending"), false);
+            m_messages[m_assistantMessageIndex] = message;
+            emit messagesChanged();
+        }
+        m_currentReply.clear();
+        setSending(false);
+        setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
+
+        // Drain any text held back by an unresolved GATED state so the user
+        // sees everything the model sent before we ask the pet to settle.
+        drainHoldBufferToPacer();
+
+        transitionTo(ChatPhase::WAITING_FOR_ANIMATION_END);
+        if (m_runtime != nullptr) {
+            m_runtime->requestBoundaryAndNotify([this]() {
+                handleBoundaryReached();
+            });
+        } else {
+            transitionTo(ChatPhase::IDLE);
+        }
+        return;
+    }
+```
+
+- [ ] **Step 4: Build and run**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  ctest --test-dir build -R chat_controller_smoke --output-on-failure
+```
+
+Expected: the new assertion passes. Earlier assertions about `RUN_FINISHED should not interrupt the current speaking state` should still pass because the state machine no longer triggers `returnToIdle` synchronously — it waits for the boundary.
+
+Note: the existing assertion `RUN_FINISHED should not restart or replace the current speaking action` should still hold because no new action is requested by the state machine; only `requestBoundaryAndNotify` is called, which doesn't start playback.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.cpp \
+        apps/desktop/tests/chat_controller_smoke.cpp
+git commit -m "feat(desktop): ChatController WAITING_FOR_ANIMATION_END on RUN_FINISHED"
+```
+
+---
+
+## Task 8: ChatController — Cancel / Error / Gate Timeout Paths
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Modify: `apps/desktop/tests/chat_controller_smoke.cpp`
+
+- [ ] **Step 1: Add the failing assertions**
+
+Open `apps/desktop/tests/chat_controller_smoke.cpp`. After the Task 7 block, append:
+
+```cpp
+    // --- Phase 2.3.1: cancel during GATED drains hold buffer and returns to IDLE ---
+    {
+        PetRuntime cRuntime;
+        ChatController cController(&cRuntime, &settings);
+
+        ChatStreamEvent cStarted;
+        cStarted.type = QStringLiteral("RUN_STARTED");
+        cController.applyStreamEvent(cStarted);
+
+        ChatStreamEvent cExpr;
+        cExpr.type = QStringLiteral("CUSTOM");
+        cExpr.name = QStringLiteral("miles.pet.expression.requested");
+        cExpr.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        cExpr.value.insert(QStringLiteral("expression"), QStringLiteral("polite"));
+        cController.applyStreamEvent(cExpr);
+
+        ChatStreamEvent cStart;
+        cStart.type = QStringLiteral("TEXT_MESSAGE_START");
+        cStart.role = QStringLiteral("assistant");
+        cController.applyStreamEvent(cStart);
+
+        ChatStreamEvent cText;
+        cText.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        cText.delta = QStringLiteral("片段");
+        cController.applyStreamEvent(cText);
+
+        // Now drive into GATED via a second expression event.
+        ChatStreamEvent cExpr2;
+        cExpr2.type = QStringLiteral("CUSTOM");
+        cExpr2.name = QStringLiteral("miles.pet.expression.requested");
+        cExpr2.value.insert(QStringLiteral("state"), QStringLiteral("speaking"));
+        cExpr2.value.insert(QStringLiteral("expression"), QStringLiteral("objection"));
+        cController.applyStreamEvent(cExpr2);
+
+        ChatStreamEvent cText2;
+        cText2.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+        cText2.delta = QStringLiteral("还有");
+        cController.applyStreamEvent(cText2);
+
+        // User cancels mid-stream.
+        cController.cancelCurrentReply();
+        require(!cController.sending(),
+                "cancel should clear sending");
+        require(cRuntime.currentState() == QStringLiteral("idle"),
+                "cancel should ask the pet to return to idle");
+    }
+```
+
+- [ ] **Step 2: Build the test — expect failure**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke 2>&1 | tail -10
+```
+
+Expected: assertion `cancel should ask the pet to return to idle` fails because the existing `cancelCurrentReply` calls `requestPetExpression("idle", "neutral")` synchronously without going through `returnToIdle`, but PetRuntime is currently in `speaking` state with an active action.
+
+(If this assertion already passes due to the existing `requestPetExpression(idle, neutral)` call, the test still adds value as a regression guard. Move on to Step 3.)
+
+- [ ] **Step 3: Update cancelCurrentReply to drain + clean-finish**
+
+Open `apps/desktop/src/chat/ChatController.cpp`. Find the existing `cancelCurrentReply()` body:
+
+```cpp
+void ChatController::cancelCurrentReply()
+{
+    if (!m_sending && m_currentReply.isNull()) {
+        return;
+    }
+
+    m_cancelled = true;
+    m_holdBuffer.clear();
+    if (m_currentReply) {
+        QNetworkReply *reply = m_currentReply;
+        m_currentReply.clear();
+        reply->abort();
+        reply->deleteLater();
+    }
+
+    if (m_assistantMessageIndex >= 0 && m_assistantMessageIndex < m_messages.size()) {
+        QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+        message.insert(QStringLiteral("pending"), false);
+        m_messages[m_assistantMessageIndex] = message;
+        emit messagesChanged();
+    }
+
+    m_assistantMessageIndex = -1;
+    setSending(false);
+    setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
+    requestPetExpression(QStringLiteral("idle"), QStringLiteral("neutral"));
+}
+```
+
+Replace with:
+
+```cpp
+void ChatController::cancelCurrentReply()
+{
+    if (!m_sending && m_currentReply.isNull() && m_phase == ChatPhase::IDLE) {
+        return;
+    }
+
+    m_cancelled = true;
+    // Per design §5.4: drain any buffered text into the pacer so the user
+    // doesn't lose visible content already on the way. The pacer will keep
+    // emitting at human pace (with backlog catch-up if necessary).
+    drainHoldBufferToPacer();
+    m_gateTimeout.stop();
+
+    if (m_currentReply) {
+        QNetworkReply *reply = m_currentReply;
+        m_currentReply.clear();
+        reply->abort();
+        reply->deleteLater();
+    }
+
+    if (m_assistantMessageIndex >= 0 && m_assistantMessageIndex < m_messages.size()) {
+        QVariantMap message = m_messages.at(m_assistantMessageIndex).toMap();
+        message.insert(QStringLiteral("pending"), false);
+        m_messages[m_assistantMessageIndex] = message;
+        emit messagesChanged();
+    }
+
+    m_assistantMessageIndex = -1;
+    setSending(false);
+    setStatusText(m_sidecarReady ? QStringLiteral("已连接") : QStringLiteral("未连接"));
+    transitionTo(ChatPhase::IDLE);
+    if (m_runtime != nullptr) {
+        m_runtime->returnToIdle();
+    }
+}
+```
+
+Find the existing `failCurrentReply()` body. After `setStatusText(QStringLiteral("错误"));`, replace the trailing `requestPetExpression(QStringLiteral("error"), QStringLiteral("neutral"));` with:
+
+```cpp
+    requestPetExpression(QStringLiteral("error"), QStringLiteral("neutral"));
+    drainHoldBufferToPacer();
+    m_gateTimeout.stop();
+    transitionTo(ChatPhase::IDLE);
+```
+
+- [ ] **Step 4: Build and run**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  ctest --test-dir build -R chat_controller_smoke --output-on-failure
+```
+
+Expected: all assertions pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.cpp \
+        apps/desktop/tests/chat_controller_smoke.cpp
+git commit -m "feat(desktop): ChatController cancel/error drain + clean-finish"
+```
+
+---
+
+## Task 9: Integrate ChatTextPacer — Replace Immediate Flush
+
+**Files:**
+- Modify: `apps/desktop/src/chat/ChatController.cpp`
+- Modify: `apps/desktop/CMakeLists.txt`
+
+(The pacer is already constructed and connected in Task 5. This task makes sure the existing `appendAssistantDelta` / `flushHoldBuffer` legacy path is fully retired so all text now flows through the pacer.)
+
+- [ ] **Step 1: Confirm the existing tests still rely on synchronous text**
+
+Open `apps/desktop/tests/chat_controller_smoke.cpp`. The original hold-buffer block (around line 120) asserts:
+
+```cpp
+require(hbController.messages().constFirst().toMap().value("text").toString()
+            == QStringLiteral("片段一"),
+        "hold buffer should flush content immediately in phase 2.1");
+```
+
+This was Phase 2.1 plumbing that no longer holds — Phase 2.3.1 routes streamed text through the pacer at `msPerChar` rate, so the text won't appear synchronously.
+
+Update those two assertions (the "片段一" and "片段一片段二" blocks) to wait for the pacer to drain. Add a small helper at the top of the file (inside the anonymous namespace):
+
+```cpp
+// Spin a Qt event loop until predicate() is true or timeoutMs elapses.
+bool waitFor(int timeoutMs, auto predicate)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (!predicate() && timer.elapsed() < timeoutMs) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 5);
+    }
+    return predicate();
+}
+```
+
+Add `#include <QElapsedTimer>` at the top.
+
+Then replace the original hold-buffer block's two assertions with:
+
+```cpp
+    // Drive the controller into STREAMING by starting and acknowledging cleanFinish.
+    ChatStreamEvent hbStarted;
+    hbStarted.type = QStringLiteral("RUN_STARTED");
+    hbController.applyStreamEvent(hbStarted);
+
+    ChatStreamEvent hbStart;
+    hbStart.type = QStringLiteral("TEXT_MESSAGE_START");
+    hbStart.role = QStringLiteral("assistant");
+    hbController.applyStreamEvent(hbStart);
+
+    ChatStreamEvent hbContent;
+    hbContent.type = QStringLiteral("TEXT_MESSAGE_CONTENT");
+    hbContent.delta = QStringLiteral("片段一");
+    hbController.applyStreamEvent(hbContent);
+
+    require(waitFor(2000, [&]() {
+                return hbController.messages().constFirst().toMap()
+                        .value(QStringLiteral("text")).toString()
+                        == QStringLiteral("片段一");
+            }),
+            "pacer should eventually deliver '片段一' to the UI");
+
+    hbContent.delta = QStringLiteral("片段二");
+    hbController.applyStreamEvent(hbContent);
+    require(waitFor(2000, [&]() {
+                return hbController.messages().constFirst().toMap()
+                        .value(QStringLiteral("text")).toString()
+                        == QStringLiteral("片段一片段二");
+            }),
+            "subsequent deltas should accumulate through the pacer");
+```
+
+The block needed `hbRuntime` to be at idle so `RUN_STARTED` flips straight to STREAMING via the synchronous cleanFinish path. The existing block constructs a fresh `PetRuntime`, which by default starts in the idle state (verified in earlier assertions), so this works.
+
+Make sure `settings.setMsPerChar(40)` is called before this block — the smoke test's default is 80 ms, but for the test we want faster drain. Add right after the `settings.setBaseUrl(...)` line at the top of `main`:
+
+```cpp
+    settings.setMsPerChar(20);
+```
+
+- [ ] **Step 2: Build and run the controller smoke test**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  ctest --test-dir build -R chat_controller_smoke --output-on-failure
+```
+
+Expected: passes. The pacer now drives all text.
+
+- [ ] **Step 3: Update the controller smoke test target to link ChatTextPacer**
+
+Open `apps/desktop/CMakeLists.txt`. Find the `qt_add_executable(ChatControllerSmoke ...)` block. Add the pacer sources:
+
+```cmake
+        src/chat/ChatTextPacer.cpp
+        src/chat/ChatTextPacer.h
+```
+
+(Add them alphabetically inside the existing source list of that target.)
+
+- [ ] **Step 4: Reconfigure and rerun all C++ tests**
+
+Run:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew && \
+  ctest --test-dir build -R "chat_controller_smoke|chat_text_pacer_smoke|pet_runtime_smoke|settings_service_smoke" --output-on-failure
+```
+
+Expected: all four pass.
+
+- [ ] **Step 5: Remove the now-unused legacy text flush path**
+
+`appendAssistantDelta` and the immediate `flushHoldBuffer` call from the TEXT_MESSAGE_CONTENT handler are no longer reachable in the normal flow (text goes through pacer when STREAMING, sits in hold buffer when buffered/gated, never via the immediate flush). However, `flushHoldBuffer` is still useful internally — it appends `m_holdBuffer` to the current assistant message directly. Replace the body of `appendAssistantDelta` and `flushHoldBuffer` to keep them no-ops or remove them entirely.
+
+Cleanest approach: delete `appendAssistantDelta` and `flushHoldBuffer` (both the declaration in `.h` and the definition in `.cpp`), since nothing calls them anymore. Quick check before deletion:
+
+```bash
+grep -n "appendAssistantDelta\|flushHoldBuffer" apps/desktop/src apps/desktop/tests
+```
+
+Expected: matches only the declarations and definitions themselves. If anything else references them, leave them in place and just comment them as deprecated.
+
+Assuming no external references, delete:
+- The declaration `void appendAssistantDelta(const QString &delta);` from `ChatController.h`.
+- The declaration `void flushHoldBuffer();` from `ChatController.h`.
+- The definitions of both methods from `ChatController.cpp`.
+
+- [ ] **Step 6: Rebuild to confirm nothing else broke**
+
+Run:
+
+```bash
+cmake --build build --target ChatControllerSmoke && \
+  cmake --build build --target MilesEdgeworthDesktop && \
+  ctest --test-dir build -R "chat_controller_smoke|chat_text_pacer_smoke" --output-on-failure
+```
+
+Expected: builds clean, tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/chat/ChatController.h \
+        apps/desktop/src/chat/ChatController.cpp \
+        apps/desktop/tests/chat_controller_smoke.cpp \
+        apps/desktop/CMakeLists.txt
+git commit -m "feat(desktop): route all streamed text through ChatTextPacer"
+```
+
+---
+
+## Task 10: Final Verification
+
+**Files:**
+- Read-only.
+
+- [ ] **Step 1: Run the contract check**
+
+Run:
+
+```bash
+python3 tests/check_phase_2_3_1_animation_sync.py
+```
+
+Expected: `phase 2.3.1 animation-text sync contract ok`. If any assertion fails, fix the corresponding file inline (do not relax assertions).
+
+- [ ] **Step 2: Run all CTest checks**
+
+Run:
+
+```bash
+cmake --build build --target MilesEdgeworthDesktop && \
+  ctest --test-dir build --output-on-failure \
+    -R "chat_text_pacer_smoke|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke|chat_stream_event_parser_smoke|skin_manifest_loader_smoke|check_phase_2_0_ai_chat_mvp|check_phase_2_1_provider|check_phase_2_2_settings|check_phase_2_3_1_animation_sync"
+```
+
+Expected: every listed test passes.
+
+- [ ] **Step 3: Run the Go sidecar tests for regression**
+
+Run:
+
+```bash
+(cd apps/agent-core && go test ./...)
+```
+
+Expected: all green. Phase 2.3.1 changes nothing on the sidecar side; this is a safety net.
+
+- [ ] **Step 4: Manual end-to-end test**
+
+If a real OpenAI-compatible endpoint is configured:
+
+1. Launch the desktop app.
+2. Send a message like "解释什么是检察官的责任，分两段回答" — a reply that should switch expressions mid-stream.
+3. Observe:
+   - Text emerges character-by-character at the configured `msPerChar` (default 80 ms).
+   - When the model switches expression (sidecar emits a new `miles.pet.expression.requested`), the current animation loop completes once before the new expression's animation starts; text pauses during the transition.
+   - When the model finishes, the current animation completes one more loop before the pet returns to idle.
+4. Cancel a long reply mid-stream:
+   - The buffered text continues to drain into the UI (don't lose visible content).
+   - The pet animates back to idle naturally.
+5. Open Settings → 文字节奏 → drag to 40 ms/字 → save. Send another message. Verify text now emerges noticeably faster.
+
+Document any observed issues here before declaring done.
+
+- [ ] **Step 5: No commit (verification only)**
+
+---
+
+## Task 11: Stage Record + Docs
+
+**Files:**
+- Create: `docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md`
+- Modify: `docs/v2/文档索引.md`
+- Modify: `docs/v2/阶段记录/Phase 2 AI 聊天粗规划.md`
+
+- [ ] **Step 1: Write the stage record**
+
+Create `docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md`:
+
+```markdown
+# Phase 2.3.1 动画-文字同步
+
+本文记录 Phase 2.3.1 的实现范围、验收方式和已知限制。Phase 2.3.1 把 ChatController 的"立即 flush"模型升级为 5 状态门控状态机，并落地字符速率限制器和 PetRuntime 的边界通知 API。Phase 2.3 剩余两块（完整 Miles persona + SQLite 会话历史、Langfuse 接入）由 2.3.2 / 2.3.3 单独完成。
+
+参考设计文档：`docs/v2/设计方案/AI 聊天动画编排设计.md` §5–7。
+
+## 完成范围
+
+- 新增 `apps/desktop/src/chat/ChatTextPacer.{h,cpp}`：QObject + QTimer 驱动的字符速率限制器，从 `SettingsService::msPerChar()` 取值，队列超过 30 字时把间隔减半。surrogate pair 一次性 emit，避免 emoji 拆字。
+- ChatController 引入 `enum class ChatPhase { IDLE, BUFFERING_FOR_START, STREAMING, GATED, WAITING_FOR_ANIMATION_END }`。各状态的事件处理与设计文档 §5.3 一致：
+  - `RUN_STARTED` → `BUFFERING_FOR_START`，调 `requestCleanFinishAndNotify`。
+  - `cleanFinishReady` → 应用 pending expression，转 `STREAMING`，hold buffer → pacer。
+  - 期间 expression 事件 → `GATED`，800ms safety timeout。
+  - `boundaryReached` → 应用 pending expression，转 `STREAMING`，hold buffer → pacer。
+  - `RUN_FINISHED` → `WAITING_FOR_ANIMATION_END`，调 `requestBoundaryAndNotify`。
+  - 该状态下 `boundaryReached` → 调 `returnToIdle`，转 `IDLE`。
+  - 用户取消 / provider 出错 / 网络断开 → drain hold buffer → pacer，转 `IDLE`，调 `returnToIdle`。
+- PetRuntime 新增 `requestBoundaryAndNotify(std::function<void()>)` 与 `requestCleanFinishAndNotify(std::function<void()>)`，二者在 2.3.1 行为一致（boundary 语义）。在 `handleAnimationFinished` 自然边界处 drain 所有 pending callback，1500ms 安全超时兜底。
+- ChatController 听 `SettingsController::saved` 后同步把新 `msPerChar` 推给 pacer。
+- 新增 `chat_text_pacer_smoke` ctest 覆盖基础流、CJK、backlog 加速、msPerChar 动态调整。
+- 扩展 `chat_controller_smoke` 覆盖 BUFFERING_FOR_START / STREAMING / GATED / WAITING_FOR_ANIMATION_END 全部转移以及 cancel 兜底。
+- 扩展 `pet_runtime_smoke` 覆盖 boundary callback 同步 / 异步两条路径。
+- 新增 `tests/check_phase_2_3_1_animation_sync.py` 静态契约。
+
+## 验收命令
+
+```bash
+python3 tests/check_phase_2_0_ai_chat_mvp.py
+python3 tests/check_phase_2_1_provider.py
+python3 tests/check_phase_2_2_settings.py
+python3 tests/check_phase_2_3_1_animation_sync.py
+(cd apps/agent-core && go test ./...)
+cmake --build build --target MilesEdgeworthDesktop
+ctest --test-dir build -R "chat_text_pacer_smoke|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke|check_phase_2_3_1_animation_sync" --output-on-failure
+```
+
+手动验收：发一段需要切换 expression 的消息 → 观察动画到自然边界后再切表达，文字按 msPerChar 节奏出 → RUN_FINISHED 后动画再循环一轮自然回 idle → 取消时已到达的文字继续吐完，但桌宠平滑回 idle。
+
+## 关键决策
+
+- **状态机直接落在 ChatController 内**：拆出 `ChatStateMachine` 类是过度抽象——状态机只为 ChatController 一个使用者服务，事件入口也只有 `applyStreamEvent` 一条。状态机数据 + handler 留在 ChatController 内可读性反而更好。
+- **`requestCleanFinishAndNotify` 与 `requestBoundaryAndNotify` 在 2.3.1 行为一致**：Phase 2.3.1 没有 phased 动画，两者都是"下一次自然边界回调"。Phase 2.4 phased 动画落地后，`requestCleanFinishAndNotify` 内部会先播 `exit` phase 再回调，不改 API。
+- **取消时 drain hold buffer**：按设计文档 §5.4 "不丢用户已经看到一半的回复"。如果用户取消时 pacer 队列很大，backlog 加速会自动缩短可见拖尾时间。
+- **`drainPendingNotifications` 在每次 `handleAnimationFinished` 都触发**：当前 Miles 皮肤的 speaking 动作都是单段 `loop` 或 `oneshot`，handleAnimationFinished 即代表"用户体感的边界"。Phase 2.4 phased 动画落地后会引入"区分 phase 内部 transition vs 真正边界"的逻辑——届时 PetRuntime 一侧扩展即可，chat 一侧不动。
+
+## 当前限制
+
+- 文字节奏只有"线性 msPerChar + backlog 半速"两段，没有按标点动态停顿、没有按句末减速。如果模型 dump 整段，目前靠 backlog 加速兜底，体验仍可接受。后续如果觉得不够拟人，可在 ChatTextPacer 加 punctuation pause。
+- Pacer emit 单位是 QChar：BMP 内的 CJK / Latin 都是 1 char；surrogate pair（emoji 等）按对 emit。如果模型大量输出超出 BMP 的字符，体验等价于"一次 emit 2 char"。
+- `requestCleanFinishAndNotify` 暂时不播 exit phase（Miles 皮肤当前 speaking 动作没有 exit 段）。Phase 2.4 phased 动画落地后这条路径才会有可见差异。
+- 没有完整的 Miles persona（仍是 Phase 2.1 留下的最小版本）；没有会话历史；没有 Langfuse。这三块由 Phase 2.3.2 / 2.3.3 接管。
+
+## 后续入口
+
+- Phase 2.3.2：完整 Miles persona prompt + SQLite 会话历史 + 新建 / 清空会话 + 历史截断策略。
+- Phase 2.3.3：Go sidecar provider 层接入 Langfuse SDK。
+- Phase 2.4：phased 动画（enter / loop / exit），PetRuntime `requestCleanFinishAndNotify` 升级为播 exit 段。
+```
+
+- [ ] **Step 2: Update the doc index**
+
+Open `docs/v2/文档索引.md`. Find the existing Phase 2.2 entry under 阶段记录:
+
+```markdown
+- [Phase 2.2 用户配置与安全存储](阶段记录/Phase%202.2%20用户配置与安全存储.md)
+```
+
+(or the form actually present). Append immediately after it:
+
+```markdown
+- [Phase 2.3.1 动画-文字同步](阶段记录/Phase%202.3.1%20动画-文字同步.md):Phase 2.3.1 的 ChatController 状态机、字符速率限制器和 PetRuntime 边界通知 API 验收记录。
+```
+
+- [ ] **Step 3: Add a "进行中" callout under Phase 2.3 in the rough plan**
+
+Open `docs/v2/阶段记录/Phase 2 AI 聊天粗规划.md`. Find the Phase 2.3 section header:
+
+```markdown
+### Phase 2.3：会话历史与人设
+```
+
+Immediately below it, insert:
+
+```markdown
+> 进行中。动画-文字同步部分（状态机 + 字符速率限制器 + PetRuntime 边界通知）已在 `阶段记录/Phase 2.3.1 动画-文字同步.md` 完成。剩余子阶段：
+> - **Phase 2.3.2**：完整 Miles persona + SQLite 会话历史 + 新建 / 清空对话 + 历史截断。
+> - **Phase 2.3.3**：Langfuse 可观测性接入（Phase 2.1 预留的 middleware hook 激活）。
+```
+
+- [ ] **Step 4: Run the contract check + commit**
+
+Run:
+
+```bash
+python3 tests/check_phase_2_3_1_animation_sync.py
+```
+
+Expected: `phase 2.3.1 animation-text sync contract ok`.
+
+Commit:
+
+```bash
+git add docs/v2/阶段记录/Phase\ 2.3.1\ 动画-文字同步.md \
+        docs/v2/文档索引.md \
+        docs/v2/阶段记录/Phase\ 2\ AI\ 聊天粗规划.md
+git commit -m "docs(phase-2-3-1): stage record + index + rough plan callout"
+```
+
+---
+
+## Self-Review
+
+### 1. Spec coverage
+
+Walking through Phase 2.3.1 scope and the design doc:
+
+- **ChatController 5-state machine** → declared in Task 5 Step 3 (`ChatPhase` enum), transitions wired in Task 5 Step 5–6 (BUFFERING_FOR_START, STREAMING), Task 6 (GATED), Task 7 (WAITING_FOR_ANIMATION_END), Task 8 (cancel → IDLE).
+- **字符速率限制器** (设计文档 §7) → ChatTextPacer in Task 2 (basic), Task 3 (backlog catch-up + msPerChar setter).
+- **PetRuntime requestBoundaryAndNotify / requestCleanFinishAndNotify** (设计文档 §6) → Task 4 with safety timeout.
+- **800 ms GATED safety timeout** (设计文档 §6.3) → ChatController.h `kGateTimeoutMs` in Task 5 Step 3, `handleGateTimeout()` in Task 5 Step 5.
+- **取消 / 错误时 drain hold buffer 到 pacer** (设计文档 §5.4) → Task 8 Step 3.
+- **msPerChar 来自 SettingsService** → ChatController constructor wiring in Task 5 Step 4.
+- **`SettingsController::saved` → pacer.setMsPerChar 同步** → Task 5 Step 4's `handleSettingsSaved` update.
+
+### 2. Placeholder scan
+
+Scanning for forbidden patterns: no "TBD" / "implement later" / "Add appropriate error handling" / "Similar to Task N" appear. Every code step has either a complete file body or an exact find/replace pair.
+
+### 3. Type consistency
+
+- `ChatPhase` enum values `IDLE, BUFFERING_FOR_START, STREAMING, GATED, WAITING_FOR_ANIMATION_END` — used identically in Task 5 (header), Task 5/6/7/8 (transitions), Task 1 (contract check assertions). ✓
+- `ChatTextPacer` API: `append(const QString &)`, `setMsPerChar(int)`, `msPerChar() const`, `pendingCount() const`, signal `chunkReady(const QString &)` — used identically in Task 2 (header), Task 2/3 (impl), Task 5 (controller integration), Task 9 (smoke test). ✓
+- `PetRuntime::requestBoundaryAndNotify(std::function<void()>)` and `requestCleanFinishAndNotify(std::function<void()>)` — declared in Task 4 Step 3, defined in Task 4 Step 4, called in Task 5 Step 6, Task 7 Step 3, Task 8 Step 3. ✓
+- `PetRuntime::drainPendingNotifications()` — defined in Task 4 Step 4, hooked into `handleAnimationFinished`. ✓
+- ChatController state machine private methods `transitionTo`, `handleCleanFinishReady`, `handleBoundaryReached`, `handleGateTimeout`, `drainHoldBufferToPacer`, `appendChunkToCurrentMessage` — declared in Task 5 Step 3, defined in Task 5 Step 5. ✓
+
+No inconsistencies found.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-22-phase-2-3-1-animation-text-sync.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/v2/文档索引.md
+++ b/docs/v2/文档索引.md
@@ -22,6 +22,7 @@
 - [皮肤包分发与加载机制设计](设计方案/皮肤包分发与加载机制设计.md)：皮肤包目录格式、`skin:` URL scheme、应用扫描三路径、Pet Skin Studio 协作关系。让最终用户无需 C++/Qt 编译环境就能换皮肤。
 - [HitZone 交互区域系统设计](设计方案/HitZone%20交互区域系统设计.md)：HitZone 坐标系、per-facing 分区模型、命中检测算法、Zone 优先级、Pet Skin Studio HitZone Panel 设计和 Miles 皮肤修复值。
 - [AI 聊天动画编排设计](设计方案/AI%20聊天动画编排设计.md)：模型流式回复与桌宠动画的同步编排——`[EXPR:x]` 标记、SSE 事件序列、ChatController 状态机、PetRuntime cleanFinish / boundary 接口、字符速率限制器。
+- [日志规范设计](设计方案/日志规范设计.md)：Qt 端和 Go sidecar 的统一日志分类体系、输出格式、文件输出机制和代码使用规范。
 
 ## 参考资料
 

--- a/docs/v2/文档索引.md
+++ b/docs/v2/文档索引.md
@@ -37,6 +37,7 @@
 - [Phase 2.0 AI Chat MVP 骨架](阶段记录/Phase%202.0%20AI%20Chat%20MVP%20骨架.md)：Phase 2.0 的 mock provider、Go sidecar、Qt ChatController、QML ChatWindow 和表达联动验收记录。
 - [Phase 2.1 OpenAI-compatible Provider](阶段记录/Phase%202.1%20OpenAI-compatible%20Provider.md)：Phase 2.1 的 OpenAI-compatible provider 接入、`[EXPR:tag]` 标记协议骨架、`Request` JSON tag 升级、hold buffer 雏形和服务端 hardening。
 - [Phase 2.2 用户配置与安全存储](阶段记录/Phase%202.2%20用户配置与安全存储.md)：Phase 2.2 的设置窗口、QSettings 非 secret 持久化、macOS Keychain API key 存储、sidecar 环境注入和验收记录。
+- [Phase 2.3.1 动画-文字同步](阶段记录/Phase%202.3.1%20动画-文字同步.md)：Phase 2.3.1 的 ChatController 状态机、字符速率限制器和 PetRuntime 边界通知 API 验收记录。
 
 ## 维护规则
 

--- a/docs/v2/设计方案/日志规范设计.md
+++ b/docs/v2/设计方案/日志规范设计.md
@@ -178,10 +178,10 @@ Debug Console（省略日期）：
 
 Qt 端和 Go sidecar 各自独立输出，不互相中转：
 
-- **Qt 端**：在 `main.cpp` 安装自定义 `qInstallMessageHandler`。日志始终写 stderr；当 `MILES_LOG_FILE` 非空时，启动时以 truncate 模式打开文件（清空上次内容），之后同一文件句柄持续写入。
+- **Qt 端**：在 `main.cpp` 安装自定义 `qInstallMessageHandler`。日志始终写 stderr；当 `MILES_LOG_FILE` 非空时，启动时先清空上次内容，随后以 append 模式持有同一文件句柄持续写入。
 - **Go sidecar**：slog 始终写 stderr；当 `MILES_LOG_FILE` 非空时（Qt 通过 `QProcessEnvironment` 传入），同时追加写入同一个文件。
 - **Debug Console 可见性**：Qt 端对 sidecar 的 `QProcess` 设置 `ForwardedErrorChannel`，sidecar 的 stderr 直接流到父进程 stderr，无需中转代码。
-- **文件写入顺序**：Qt 端在启动时以写入模式打开文件（清空），sidecar 启动后以 `O_APPEND` 模式打开。两个进程写同一个文件是 best-effort——`O_APPEND` 保证写入位置原子追加到文件末尾，但不保证两个进程的日志行严格按时间排序。实际上日志行很短且写入频率低，交错极少发生，对调试用途足够。不承诺严格的跨进程时序。
+- **文件写入顺序**：Qt 端启动时只负责清空一次日志文件，随后和 sidecar 一样以追加语义写入。两个进程写同一个文件是 best-effort——追加写入能避免覆盖另一个进程已写入的日志，但不保证两个进程的日志行严格按时间排序。实际上日志行很短且写入频率低，交错极少发生，对调试用途足够。不承诺严格的跨进程时序。
 - **清理**：删除 `ChatController` 中的 `readyReadStandardError` 连接和 `logProcessOutput` 函数。
 
 ### 5.3 launch.json 配置
@@ -246,7 +246,7 @@ logger.Error("http request failed", "status", resp.StatusCode)
 - 只对 `miles.*` 开头的 category 应用自定义格式（转大写、按 §4.1 模板拼装）
 - 非 `miles.*` category（Qt/QML 内部 warning 等）不应用自定义格式。安装 handler 时保存 `qInstallMessageHandler` 的返回值（previous handler）；遇到非 `miles.*` 日志时，若 previous handler 非空则调用它，否则用 `qFormatLogMessage(type, context, msg)` 格式化后写 stderr，以模拟 Qt 默认行为
 - 输出到 stderr（始终）
-- 当 `MILES_LOG_FILE` 非空时，启动时以 truncate 模式打开文件（清空上次内容），之后同一文件句柄持续写入（带日期前缀）。非 `miles.*` 的日志也写入文件，但保持 Qt 默认格式
+- 当 `MILES_LOG_FILE` 非空时，启动时先清空上次内容，随后以 append 模式持有同一文件句柄持续写入（带日期前缀）。非 `miles.*` 的日志也写入文件，但保持 Qt 默认格式
 
 ### 7.2 Go slog 初始化
 

--- a/docs/v2/设计方案/日志规范设计.md
+++ b/docs/v2/设计方案/日志规范设计.md
@@ -1,0 +1,275 @@
+# 日志规范设计
+
+本文档定义 MilesEdgeworth 项目的日志规范，覆盖 Qt 桌面端和 Go sidecar，提供统一的分类体系、输出格式和文件输出机制。
+
+## 1. 设计目标
+
+- 能看到大模型交互细节：token 解析状态、事件分发、表达标记提取、有没有丢失或格式错误。需要时可临时开启原文输出（见 §4.4）。
+- 能追踪动画切换流程：状态机的每次转换、请求了什么表达、PetRuntime 做了什么决策。
+- 能定位竞态和时序问题：事件的先后顺序和时间戳，判断 gate timeout、boundary notify 等是否正确触发。
+- 日志清晰可读：格式统一、有分类、能快速过滤，不是一堆杂乱的 key=value dump。
+
+非目标：
+
+- 不做日志轮转或压缩——桌宠应用单次运行日志量很小。
+- 不做远程日志收集——这是本地开发工具。
+- 不做 UI 日志面板——通过 VS Code Debug Console 或日志文件查看。
+
+## 2. 日志分类体系
+
+所有分类名以 `MILES.` 开头，按 `MILES.<模块>.<子系统>` 层级组织。
+
+### 2.1 分类清单
+
+| 分类 | 覆盖内容 | 使用端 |
+|------|---------|--------|
+| `MILES.CHAT` | SSE 事件收发、状态机转换、sidecar 进程管理 | Qt ChatController |
+| `MILES.CHAT.PROVIDER` | 模型请求参数、原始 token 解析、表达标记提取 | Go sidecar openai provider |
+| `MILES.CHAT.PACER` | 文字节奏队列状态（按需启用） | Qt ChatTextPacer |
+| `MILES.PET.RUNTIME` | action 播放、boundary 通知、recipe 执行 | Qt PetRuntime |
+| `MILES.PET.EXPRESSION` | 表达映射解析、选择、降级逻辑 | Qt ExpressionMappingResolver |
+| `MILES.SIDECAR` | sidecar 启动、HTTP 路由、health check | Go main/server |
+| `MILES.SETTINGS` | 设置读写（未来按需添加） | Qt SettingsService |
+| `MILES.APP` | 应用启动、QML 引擎初始化（未来按需添加） | Qt main.cpp |
+
+### 2.2 命名规则
+
+分类名 = `MILES.` + 描述模块职责的关键词，按抽象含义命名，不是机械映射目录路径。
+
+命名时问自己：**这段日志在干什么？** 选一个能回答这个问题的名字。
+
+- `MILES.CHAT`：聊天流程控制（不叫 `MILES.DESKTOP.SRC.CHAT`）
+- `MILES.PET.RUNTIME`：桌宠动画调度（不叫 `MILES.PET`，因为 pet 下有多个独立子系统）
+- `MILES.PET.EXPRESSION`：表达映射解析（不叫 `MILES.PET.SELECTION`，因为 `selection` 是目录名但不表达含义）
+- `MILES.CHAT.PROVIDER`：模型请求和 token 解析
+- `MILES.SIDECAR`：sidecar 进程生命周期
+
+规则：
+
+- 同一职责的文件共享同一个分类，即使它们分布在不同目录。
+- 只有当一个子系统的日志量大到需要单独过滤时，才拆出子分类。
+- 每个源文件在顶部声明一次分类（Qt 用 `Q_LOGGING_CATEGORY`，Go 用项目封装的 `mileslog.New`），之后该文件中所有日志调用直接引用这个变量，不需要重复指定分类名。
+
+### 2.3 Qt 端分类声明
+
+Qt 端分类名在 `Q_LOGGING_CATEGORY` 中使用小写点分格式（项目约定，与 `QT_LOGGING_RULES` 的过滤语法一致），输出时由 message handler 转为大写显示：
+
+```cpp
+// 声明（小写点分，项目约定）
+Q_LOGGING_CATEGORY(chatLog, "miles.chat", QtInfoMsg)
+
+// 使用
+qCDebug(chatLog) << "stream event" << "type=" << event.type;
+```
+
+输出显示为 `[MILES.CHAT]`。
+
+### 2.4 Go 端分类声明
+
+Go 端通过项目封装的 `mileslog` 包创建带分类的 logger：
+
+```go
+// internal/mileslog/mileslog.go 提供的封装
+// New 返回一个 *slog.Logger，使用 mileslog 包内部管理的 handler，
+// 并携带固定的 category 属性。
+// mileslog 包在 init() 中完成 handler 初始化（读取 MILES_LOG_LEVEL、
+// MILES_LOG_FILE 等环境变量），不依赖 main() 中的 slog.SetDefault。
+func New(category string) *slog.Logger
+
+// provider.go 文件顶部
+var logger = mileslog.New("MILES.CHAT.PROVIDER")
+
+logger.Debug("expression tag parsed", "tag", tag)
+```
+
+注意事项：
+
+- 不直接用 `slog.WithGroup`——`WithGroup` 的语义是给后续属性加前缀，不是设置分类标签。用 `With("category", ...)` 确保分类名始终出现在输出中。
+- `mileslog` 包在自己的 `init()` 中完成 handler 创建和环境变量解析，不调用 `slog.Default()`。这样包级变量 `var logger = mileslog.New(...)` 在 `main()` 之前初始化时就能拿到正确的 handler。
+
+## 3. 日志级别
+
+四个级别，含义明确：
+
+| 级别 | 何时用 | 示例 |
+|------|--------|------|
+| `ERROR` | 影响功能的错误，用户会感知到问题 | sidecar 启动失败、模型请求 HTTP 错误、SSE 解析异常 |
+| `WARN` | 不影响功能但不符合预期 | 未知 expression tag 降级为 neutral、boundary 安全超时触发 |
+| `INFO` | 关键业务节点 | sidecar 启动/连接成功、聊天会话开始/结束、皮肤切换 |
+| `DEBUG` | 开发调试用的详细信息 | 每个 SSE 事件、状态机每次转换、token 解析细节 |
+
+默认级别：
+
+- Qt 端：`INFO`（`Q_LOGGING_CATEGORY` 第三参数 `QtInfoMsg`）。`QT_LOGGING_RULES` 开 debug。
+- Go 端：`INFO`。`MILES_LOG_LEVEL=debug` 开 debug。
+
+生产环境：`DEBUG` 被静默，用户看不到任何日志（GUI 应用无终端窗口，不写文件）。两端的过滤行为有差异：
+
+- **Qt 端**：`qCDebug` 宏在 category 禁用时跳过整个 stream 表达式，参数不会求值，开销接近零。
+- **Go 端**：`slog.Debug(...)` 的调用参数在函数调用前求值，即使日志最终被过滤。避免在 debug 日志参数中传入开销大的表达式（如 `fmt.Sprintf`、大结构体序列化）。
+
+## 4. 输出格式
+
+### 4.1 格式模板
+
+```
+时间戳 级别 [分类] 消息内容 key=value ... [来源文件:行号]
+```
+
+### 4.2 示例
+
+Debug Console（省略日期）：
+
+```
+17:12:20.123 INFO  [MILES.CHAT] send chat request messageLen=12 expressions=5 [ChatController.cpp:302]
+17:12:20.200 DEBUG [MILES.SIDECAR] request prepared model=deepseek-chat expressions=5 [provider.go:148]
+17:12:20.450 DEBUG [MILES.CHAT.PROVIDER] stream started knownTags=objection,polite,neutral [provider.go:185]
+17:12:20.512 DEBUG [MILES.CHAT.PROVIDER] expression tag parsed tag=objection [provider.go:269]
+17:12:20.513 DEBUG [MILES.CHAT] expression requested phase=1 state=speaking expression=objection [ChatController.cpp:508]
+17:12:20.514 DEBUG [MILES.PET.EXPRESSION] resolve expression requested=objection resolved=objection candidates=2 [ExpressionMappingResolver.cpp:132]
+17:12:20.515 DEBUG [MILES.PET.RUNTIME] play action requested=speak-objection resolved=speak-objection [PetRuntime.cpp:436]
+17:12:21.100 DEBUG [MILES.CHAT.PROVIDER] stream finished [provider.go:302]
+17:12:21.101 INFO  [MILES.CHAT] run finished phase=2 [ChatController.cpp:461]
+```
+
+文件日志（带日期）：
+
+```
+2026-05-22 17:12:20.123 INFO  [MILES.CHAT] send chat request messageLen=12 expressions=5 [ChatController.cpp:302]
+```
+
+### 4.3 格式约定
+
+- **时间戳**：文件日志带日期 `YYYY-MM-DD HH:MM:SS.mmm`，Debug Console 省日期 `HH:MM:SS.mmm`。
+- **级别**：全大写，固定 5 字符宽度（`DEBUG` / `INFO ` / `WARN ` / `ERROR`），右补空格对齐。
+- **分类**：全大写，方括号包裹。
+- **消息内容**：英文小写短句，不加句号，动词开头。
+- **结构化参数**：`key=value` 格式，key 用 camelCase。
+- **来源位置**：`[文件名:行号]`，方括号包裹，位于行末。Qt 端由 `QMessageLogContext` 自动提供；Go 端由自定义 handler 从 `record.PC` 通过 `runtime.CallersFrames` 提取。两端都无需手动维护。
+
+### 4.4 安全约束
+
+默认不打印以下内容：
+
+- API key 值（任何级别都不允许）
+- 用户消息原文
+- 模型输出原文
+
+可以打印长度（`messageLen=12`）、有无（`apiKeySet=true`）等脱敏信息。
+
+**Payload 原文开关**：设置环境变量 `MILES_LOG_PAYLOADS=1` 时，允许 DEBUG 级别打印用户消息和模型输出原文，用于本地排查 token 解析和表达标记提取问题。注意事项：
+
+- 仅限本地开发临时使用，不要提交包含原文的日志文件。
+- API key 即使开启此开关也**绝不打印**。
+- Qt 端也能接触到原文（用户输入经过 `sendMessage`，模型输出经过 `TEXT_MESSAGE_CONTENT`），同样受此开关控制——默认不得打印，开启后才允许。目前 payload 日志只在 Go 端实现，Qt 端未来如需添加也必须受同一开关约束。
+
+## 5. 文件输出
+
+### 5.1 环境变量
+
+| 环境变量 | 作用 | 默认值 | 示例 |
+|---------|------|--------|------|
+| `QT_LOGGING_RULES` | Qt 端日志级别过滤 | `miles.*.debug=false` | `miles.*.debug=true` |
+| `MILES_LOG_LEVEL` | Go sidecar 日志级别 | `info` | `debug` |
+| `MILES_LOG_FILE` | 日志文件路径 | 空（不写文件） | `~/Library/Logs/MilesEdgeworth/miles.log` |
+| `MILES_LOG_PAYLOADS` | 允许 DEBUG 打印用户消息和模型输出原文 | 空（不打印） | `1` |
+
+### 5.2 输出机制
+
+Qt 端和 Go sidecar 各自独立输出，不互相中转：
+
+- **Qt 端**：在 `main.cpp` 安装自定义 `qInstallMessageHandler`。日志始终写 stderr；当 `MILES_LOG_FILE` 非空时，启动时以 truncate 模式打开文件（清空上次内容），之后同一文件句柄持续写入。
+- **Go sidecar**：slog 始终写 stderr；当 `MILES_LOG_FILE` 非空时（Qt 通过 `QProcessEnvironment` 传入），同时追加写入同一个文件。
+- **Debug Console 可见性**：Qt 端对 sidecar 的 `QProcess` 设置 `ForwardedErrorChannel`，sidecar 的 stderr 直接流到父进程 stderr，无需中转代码。
+- **文件写入顺序**：Qt 端在启动时以写入模式打开文件（清空），sidecar 启动后以 `O_APPEND` 模式打开。两个进程写同一个文件是 best-effort——`O_APPEND` 保证写入位置原子追加到文件末尾，但不保证两个进程的日志行严格按时间排序。实际上日志行很短且写入频率低，交错极少发生，对调试用途足够。不承诺严格的跨进程时序。
+- **清理**：删除 `ChatController` 中的 `readyReadStandardError` 连接和 `logProcessOutput` 函数。
+
+### 5.3 launch.json 配置
+
+```json
+{
+  "environment": [
+    { "name": "QT_LOGGING_RULES", "value": "miles.*.debug=true" },
+    { "name": "MILES_LOG_LEVEL", "value": "debug" },
+    { "name": "MILES_LOG_FILE", "value": "${workspaceFolder}/miles-debug.log" },
+    { "name": "MILES_LOG_PAYLOADS", "value": "1" }
+  ]
+}
+```
+
+`MILES_LOG_FILE` 是可选的，不设就只在 Debug Console 看。
+
+## 6. 代码使用方式
+
+### 6.1 Qt 端
+
+```cpp
+// 文件顶部，匿名命名空间内声明分类
+namespace {
+Q_LOGGING_CATEGORY(chatLog, "miles.chat", QtInfoMsg)
+}
+
+// 写日志
+qCDebug(chatLog) << "stream event" << "type=" << event.type << "deltaLen=" << event.delta.size();
+qCInfo(chatLog) << "send chat request" << "messageLen=" << trimmed.size();
+qCWarning(chatLog) << "unknown expression tag" << "tag=" << tag;
+qCCritical(chatLog) << "sidecar process crashed" << "exitCode=" << exitCode;
+```
+
+### 6.2 Go 端
+
+```go
+// 文件顶部定义带分类的 logger
+var logger = mileslog.New("MILES.CHAT.PROVIDER")
+
+// 写日志
+logger.Debug("expression tag parsed", "tag", tag)
+logger.Info("stream started", "knownTags", strings.Join(knownTags, ","))
+logger.Warn("unknown expression tag fallback", "tag", tag, "fallback", "neutral")
+logger.Error("http request failed", "status", resp.StatusCode)
+```
+
+### 6.3 迁移规则
+
+- Go 端所有 `debugf(...)` → `logger.Debug(...)`
+- Go 端所有 `log.Printf(...)` → `slog.Info(...)` 或 `logger.Info(...)`
+- Go 端删除 `debugLoggingEnabled` 变量和 `SetDebugLogging` 函数，用 slog 级别控制替代
+- Go 端 `MILES_DEBUG_CHAT` 环境变量用 `MILES_LOG_LEVEL` 替代
+- Qt 端现有 `qCDebug` 调用保持不变，只需统一消息风格（英文小写短句、key=value 参数）
+
+## 7. 实现要点
+
+### 7.1 Qt message handler
+
+在 `main.cpp` 中安装自定义 handler：
+
+- 只对 `miles.*` 开头的 category 应用自定义格式（转大写、按 §4.1 模板拼装）
+- 非 `miles.*` category（Qt/QML 内部 warning 等）不应用自定义格式。安装 handler 时保存 `qInstallMessageHandler` 的返回值（previous handler）；遇到非 `miles.*` 日志时，若 previous handler 非空则调用它，否则用 `qFormatLogMessage(type, context, msg)` 格式化后写 stderr，以模拟 Qt 默认行为
+- 输出到 stderr（始终）
+- 当 `MILES_LOG_FILE` 非空时，启动时以 truncate 模式打开文件（清空上次内容），之后同一文件句柄持续写入（带日期前缀）。非 `miles.*` 的日志也写入文件，但保持 Qt 默认格式
+
+### 7.2 Go slog 初始化
+
+在 `internal/mileslog/` 包中实现，`init()` 时自动完成初始化（不依赖 `main()`）：
+
+- 在 `init()` 中解析 `MILES_LOG_LEVEL` 环境变量设定级别（默认 `INFO`）
+- 实现自定义 `slog.Handler`（不用 `TextHandler`——`TextHandler` 的输出格式是 `time=... level=... msg=...`，`ReplaceAttr` 只能改属性值不能重排布局，无法实现 §4.1 的格式）
+- 自定义 handler 按 §4.1 格式输出：`时间戳 级别 [分类] 消息 key=value ... [文件:行号]`
+- 从 `record.PC` 通过 `runtime.CallersFrames` 提取文件名和行号（`slog.Record` 没有 `Source` 字段，只有 `PC uintptr`）
+- 从 record 的属性中提取 `category` 字段（由 `mileslog.New` 注入），格式化为 `[CATEGORY]`
+- 输出到 stderr；在 `init()` 中检查 `MILES_LOG_FILE`，非空时同时以 `O_APPEND` 写入文件
+- `main.go` 不需要做任何 slog 初始化，只需删除旧的 `log.Printf` 和 `debugLoggingEnabled` 相关代码
+
+### 7.3 Sidecar 日志独立输出
+
+不再中转。Qt 端和 sidecar 各自独立写 stderr 和文件：
+
+- Qt 端在 `ChatController` 构造时对 `m_sidecarProcess` 调用 `setProcessChannelMode(QProcess::ForwardedErrorChannel)`，sidecar 的 stderr 直接流到父进程 stderr。
+- 删除 `readyReadStandardError` 连接和 `logProcessOutput` 函数。Go panic 堆栈也走 stderr，`ForwardedErrorChannel` 会将其直接输出到父进程 stderr / Debug Console。
+- Qt 在启动 sidecar 时通过 `QProcessEnvironment` 传入 `MILES_LOG_FILE`、`MILES_LOG_LEVEL` 和 `MILES_LOG_PAYLOADS`，sidecar 自行决定是否写文件和是否打印原文。
+
+## 8. 文档维护规则
+
+- 新增日志分类时同步更新 §2.1 分类清单。
+- 修改输出格式时同步更新 §4。
+- 修改环境变量时同步更新 §5.1。

--- a/docs/v2/阶段记录/Phase 2 AI 聊天粗规划.md
+++ b/docs/v2/阶段记录/Phase 2 AI 聊天粗规划.md
@@ -151,6 +151,10 @@ Go sidecar（`apps/agent-core`）、QML `ChatWindow`、C++ `ChatController`、mo
 
 ### Phase 2.3：会话历史与人设
 
+> 进行中。动画-文字同步部分（状态机 + 字符速率限制器 + PetRuntime 边界通知）已在 `阶段记录/Phase 2.3.1 动画-文字同步.md` 完成。剩余子阶段：
+> - **Phase 2.3.2**：完整 Miles persona + SQLite 会话历史 + 新建 / 清空对话 + 历史截断。
+> - **Phase 2.3.3**：Langfuse 可观测性接入（Phase 2.1 预留的 middleware hook 激活）。
+
 目标：让 Miles 有稳定人设和基础上下文，并完整落地动画-文字同步状态机。
 
 范围：

--- a/docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md
+++ b/docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md
@@ -1,0 +1,50 @@
+# Phase 2.3.1 动画-文字同步
+
+本文记录 Phase 2.3.1 的实现范围、验收方式和已知限制。Phase 2.3.1 把 ChatController 的“立即 flush”模型升级为 5 状态门控状态机，并落地字符速率限制器和 PetRuntime 的边界通知 API。Phase 2.3 剩余两块（完整 Miles persona + SQLite 会话历史、Langfuse 接入）由 2.3.2 / 2.3.3 单独完成。
+
+参考设计文档：`docs/v2/设计方案/AI 聊天动画编排设计.md` §5-7。
+
+## 完成范围
+
+- 新增 `apps/desktop/src/chat/ChatTextPacer.{h,cpp}`：QObject + QTimer 驱动的字符速率限制器，从 `SettingsService::msPerChar()` 取值，队列超过 30 字时把间隔减半。surrogate pair 一次性 emit，避免 emoji 拆字。
+- ChatController 引入 `enum class ChatPhase { IDLE, BUFFERING_FOR_START, STREAMING, GATED, WAITING_FOR_ANIMATION_END }`。各状态的事件处理与设计文档 §5.3 一致。
+- PetRuntime 新增 `requestBoundaryAndNotify(std::function<void()>)` 与 `requestCleanFinishAndNotify(std::function<void()>)`，二者在 2.3.1 行为一致，均在动画自然边界回调，并带 1500ms 安全超时。
+- ChatController 听 `SettingsController::saved` 后同步把新 `msPerChar` 推给 pacer。
+- 新增 `chat_text_pacer_smoke` ctest 覆盖基础流、CJK、backlog 加速、msPerChar 动态调整。
+- 扩展 `chat_controller_smoke` 覆盖 BUFFERING_FOR_START / STREAMING / GATED / WAITING_FOR_ANIMATION_END 转移以及 cancel / error 兜底。
+- 扩展 `pet_runtime_smoke` 覆盖 boundary callback 同步 / 异步路径，以及边界通知不吞掉原有动画收尾流程。
+- 新增 `tests/check_phase_2_3_1_animation_sync.py` 静态契约。
+
+## 验收命令
+
+```bash
+python3 tests/check_phase_2_0_ai_chat_mvp.py
+python3 tests/check_phase_2_1_provider.py
+python3 tests/check_phase_2_2_settings.py
+python3 tests/check_phase_2_3_1_animation_sync.py
+(cd apps/agent-core && go test ./...)
+cmake --build build --target MilesEdgeworthDesktop
+ctest --test-dir build -R "chat_text_pacer_smoke|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke|check_phase_2_3_1_animation_sync" --output-on-failure
+```
+
+手动验收：发一段需要切换 expression 的消息，观察动画到自然边界后再切表达，文字按 `msPerChar` 节奏流出；`RUN_FINISHED` 后动画再自然结束才回 idle；取消或错误时已进入 hold buffer 的文字继续吐完，不产生新幽灵消息。
+
+## 关键决策
+
+- **状态机直接落在 ChatController 内**：状态机只服务 ChatController 一个使用者，事件入口也集中在 `applyStreamEvent`，拆独立类暂时没有收益。
+- **`requestCleanFinishAndNotify` 与 `requestBoundaryAndNotify` 在 2.3.1 行为一致**：当前还没有 phased speaking 动画，两者都是“下一次自然边界回调”。Phase 2.4 phased 动画落地后，`requestCleanFinishAndNotify` 内部会先播 `exit` phase 再回调，不改 API。
+- **取消和错误时 drain hold buffer**：不丢已经到达本地、即将显示的文本。pacer 会继续按人类节奏吐完，同时 `m_cancelled` 仍阻止后续残留 SSE 新建消息。
+- **`drainPendingNotifications` 不短路 PetRuntime 原有收尾流程**：边界 callback 只是通知 ChatController，`handleAnimationFinished()` 仍继续处理 `facingAfter`、recipe 下一步、pending request 和 `onceThenIdle` 回 idle。
+
+## 当前限制
+
+- 文字节奏只有“线性 msPerChar + backlog 半速”两段，没有按标点动态停顿。
+- Pacer emit 单位是 QChar；BMP 内的 CJK / Latin 都是 1 char，surrogate pair 按对 emit。
+- `requestCleanFinishAndNotify` 暂时不播 exit phase。Phase 2.4 phased 动画落地后这条路径才会有可见差异。
+- 完整 Miles persona、SQLite 会话历史和 Langfuse 仍由 Phase 2.3.2 / 2.3.3 接管。
+
+## 后续入口
+
+- Phase 2.3.2：完整 Miles persona prompt + SQLite 会话历史 + 新建 / 清空会话 + 历史截断策略。
+- Phase 2.3.3：Go sidecar provider 层接入 Langfuse SDK。
+- Phase 2.4：phased 动画（enter / loop / exit），PetRuntime `requestCleanFinishAndNotify` 升级为播 exit 段。

--- a/docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md
+++ b/docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md
@@ -43,6 +43,90 @@ ctest --test-dir build -R "chat_text_pacer_smoke|chat_controller_smoke|pet_runti
 - `requestCleanFinishAndNotify` 暂时不播 exit phase。Phase 2.4 phased 动画落地后这条路径才会有可见差异。
 - 完整 Miles persona、SQLite 会话历史和 Langfuse 仍由 Phase 2.3.2 / 2.3.3 接管。
 
+## 设计评审待处理问题
+
+以下问题来自 Phase 2.3.1 联调和用户手测。它们先作为 `AI 聊天动画编排设计.md` 的评审输入保留；在长期方案更新前，不应继续用局部补丁扩大动画编排实现。
+
+### 1. `RUN_FINISHED` 早于起始动画边界
+
+现象：模型能先发出 `miles.pet.expression.requested { state: "speaking", expression: "objection" }`，但短回复场景下 `RUN_FINISHED` 会在 `BUFFERING_FOR_START` 等待当前动画干净收尾期间到达。旧实现会清空 pending expression，导致文字显示了，桌宠没有进入 `objecting` / `crossed`。
+
+设计缺口：`AI 聊天动画编排设计.md` §5.3 只说明 `BUFFERING_FOR_START` 中 expression 和 text 如何处理，没有定义 `RUN_FINISHED during BUFFERING_FOR_START`。评审时需要明确：
+
+- 起始 expression 是否必须保留并播放，即使回复已经结束。
+- hold buffer 是否必须等起始 expression 实际请求后才放行。
+- 起始 expression 播放后，是等待该 expression 动画边界再回 idle，还是允许文字结束后立即回 idle。
+
+### 2. 边界回调可能替换当前动画
+
+现象：`PetRuntime::handleAnimationFinished()` 在 drain pending notification 时会执行 ChatController 回调；回调可能立刻请求并播放新的 expression 动画。旧实现继续执行原动画的 finish 流程，可能把刚切出的 expression 立刻覆盖回 idle。
+
+设计缺口：`AI 聊天动画编排设计.md` §6 定义了边界通知 API，但没有定义 callback 的重入语义。评审时需要明确：
+
+- callback 是否允许同步请求新动画。
+- 如果 callback 改变了当前 playback，旧的 `handleAnimationFinished()` 是否必须停止后续收尾逻辑。
+- Runtime 是否需要统一的 playback serial / generation 机制，避免旧边界事件污染新动画。
+
+### 3. 单个 pending expression 无法表达多段排队
+
+当前设计在 `GATED` 中使用“覆盖待请求 expression”的模型：新的 expression 到达时覆盖上一条 pending expression，文字进入同一个 hold buffer。若模型在当前动画边界前连续输出多个 expression 段，可能出现 hold buffer 中包含多段语义文本，但最终只按最后一个 expression 播放，造成“文字和动作不对应”。
+
+评审时需要决定是否从 `pendingExpression + holdBuffer` 升级为 segment queue：
+
+```text
+[{ expression: objection, text: "异议！..." },
+ { expression: polite, text: "不过..." }]
+```
+
+每个 segment 等待自己的动画边界后再放行对应文字。若仍保留“覆盖最新 expression”的策略，需要明确这是有意降级，并写清楚会牺牲中间 expression 的同步精度。
+
+### 4. `RUN_FINISHED` 与 `GATED` / pacer drain 的关系不清楚
+
+设计目前主要描述 `STREAMING -> WAITING_FOR_ANIMATION_END`，但手测中可能出现：
+
+- `RUN_FINISHED` 到达时仍在 `GATED`，还有文本停在 hold buffer。
+- `RUN_FINISHED` 到达后，pacer 仍在按人类节奏吐字。
+- expression 动画已经到边界，但 UI 文字尚未吐完。
+
+评审时需要明确“回复结束”的判定到底由哪些条件共同决定：
+
+- provider stream 已结束。
+- hold buffer 已清空。
+- pacer 队列已清空。
+- 当前 expression 动画已到自然边界。
+
+否则容易出现文字还在显示，桌宠已经回 idle；或桌宠还在动作，聊天 UI 已经结束 pending 状态。
+
+### 5. `requestBoundaryAndNotify` 和 `requestCleanFinishAndNotify` 在 Phase 2.4 前后的语义
+
+当前 2.3.1 没有 phased speaking 动画，两个接口暂时都只能等单段 GIF 的自然边界。Phase 2.4 引入 enter / loop / exit 后，两者才会有可见差异。
+
+评审时需要补充一张从“当前单段 GIF”到“未来 phased action”的兼容表，说明：
+
+- 单段 loop、单段 once、onceThenIdle、phased enter / loop / exit 分别如何处理 boundary 和 clean finish。
+- Phase 2.3.1 的 fallback 行为是否仍然合法。
+- `interruptHint` 如何影响这两个接口，例如立即切换、播完当前 once、等 loop 边界、播 exit 后切换。
+
+### 6. 起始同步的体验取舍
+
+目标是“expression 先到，动作尽快切，文字随动作输出”。但如果当前动画很长，严格等待 clean finish 会让用户感觉回复卡住；如果立即硬切，又违背自然收尾目标。
+
+评审时需要明确起始同步策略：
+
+- 是否需要针对 idle / thinking / once / loop 使用不同默认策略。
+- 是否允许模型或 sidecar 通过 `interruptHint` 表达“强动作优先”。
+- 安全超时应该是 ChatController 层、PetRuntime 层，还是两层都有；超时时是否需要记录 debug / warning 日志。
+
+### 7. expression 到具体 action 的随机映射影响验收
+
+`objection` 目前可能映射到多个动作，例如 `objecting` 或 `crossed`。这对自然感有价值，但手测时用户可能期待“异议”一定播 `objecting`。
+
+评审时需要区分：
+
+- expression 语义层验收：确认 `objection` 被解析并请求。
+- action 选择层验收：允许按权重随机选中多个 action。
+- 特定剧情 / 强语义动作是否需要 `selection: first_available` 或显式 action request，而不是走随机 expression mapping。
+
 ## 后续入口
 
 - Phase 2.3.2：完整 Miles persona prompt + SQLite 会话历史 + 新建 / 清空会话 + 历史截断策略。

--- a/tests/check_logging_standard.py
+++ b/tests/check_logging_standard.py
@@ -113,6 +113,12 @@ def main() -> int:
             "Pet expression debug logs should use noquote formatting")
     require("\"message=\" << trimmed" not in chat_cpp and "\"text=\" << event.delta" not in chat_cpp,
             "ChatController must not log user or model text payloads")
+    require(".arg(env.contains(" not in chat_cpp and ".arg(healthy)" not in chat_cpp,
+            "ChatController boolean log fields should render true/false text")
+    require(".arg(request.hideCurrentProp)" not in runtime_cpp
+            and ".arg(resetRecipe)" not in runtime_cpp
+            and ".arg(replacingActiveAnimation)" not in runtime_cpp,
+            "PetRuntime boolean log fields should render true/false text")
 
     print("logging standard contract ok")
     return 0

--- a/tests/check_logging_standard.py
+++ b/tests/check_logging_standard.py
@@ -31,6 +31,8 @@ def main() -> int:
     qt_handler_smoke = read("apps/desktop/tests/logging_formatter_smoke.cpp")
     desktop_main = read("apps/desktop/src/main.cpp")
     chat_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    runtime_cpp = read("apps/desktop/src/pet/PetRuntime.cpp")
+    expression_cpp = read("apps/desktop/src/pet/selection/ExpressionMappingResolver.cpp")
     desktop_cmake = read("apps/desktop/CMakeLists.txt")
     root_cmake = read("CMakeLists.txt")
 
@@ -55,6 +57,8 @@ def main() -> int:
 
     require("MILES_DEBUG_CHAT" not in main_go + provider_go,
             "MILES_DEBUG_CHAT must be removed")
+    require("PayloadLoggingEnabled" in provider_go,
+            "provider must guard raw payload logs behind MILES_LOG_PAYLOADS")
     require("SetDebugLogging" not in provider_go,
             "openai.SetDebugLogging must be removed")
     require("debugf(" not in provider_go,
@@ -95,6 +99,20 @@ def main() -> int:
             "ChatController logProcessOutput helper must be removed")
     require("MILES_LOG_PAYLOADS" in chat_cpp,
             "ChatController must forward MILES_LOG_PAYLOADS to sidecar")
+    require(".noquote()" in chat_cpp,
+            "ChatController should use noquote key=value debug logs")
+    require(".noquote()" in runtime_cpp,
+            "PetRuntime should use noquote key=value debug logs")
+    require(".noquote()" in expression_cpp,
+            "ExpressionMappingResolver should use noquote key=value debug logs")
+    require("qCDebug(chatLog) <<" not in chat_cpp,
+            "ChatController debug logs should use noquote formatting")
+    require("qCDebug(petRuntimeLog) <<" not in runtime_cpp,
+            "PetRuntime runtime debug logs should use noquote formatting")
+    require("qCDebug(petExpressionLog) <<" not in runtime_cpp + expression_cpp,
+            "Pet expression debug logs should use noquote formatting")
+    require("\"message=\" << trimmed" not in chat_cpp and "\"text=\" << event.delta" not in chat_cpp,
+            "ChatController must not log user or model text payloads")
 
     print("logging standard contract ok")
     return 0

--- a/tests/check_logging_standard.py
+++ b/tests/check_logging_standard.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Check the unified logging-standard implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    file_path = ROOT / path
+    if not file_path.exists():
+        raise AssertionError(f"missing file: {path}")
+    return file_path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    mileslog = read("apps/agent-core/internal/mileslog/mileslog.go")
+    mileslog_test = read("apps/agent-core/internal/mileslog/mileslog_test.go")
+    main_go = read("apps/agent-core/cmd/miles-agent/main.go")
+    provider_go = read("apps/agent-core/internal/chat/openai/provider.go")
+    qt_handler_h = read("apps/desktop/src/logging/MilesLogHandler.h")
+    qt_handler_cpp = read("apps/desktop/src/logging/MilesLogHandler.cpp")
+    qt_handler_smoke = read("apps/desktop/tests/logging_formatter_smoke.cpp")
+    desktop_main = read("apps/desktop/src/main.cpp")
+    chat_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    desktop_cmake = read("apps/desktop/CMakeLists.txt")
+    root_cmake = read("CMakeLists.txt")
+
+    require("package mileslog" in mileslog, "Go mileslog package must exist")
+    require("func New(category string) *slog.Logger" in mileslog,
+            "mileslog.New(category) must be exported")
+    require("func PayloadLoggingEnabled() bool" in mileslog,
+            "mileslog must expose PayloadLoggingEnabled")
+    require("type handler struct" in mileslog and "slog.Handler" in mileslog,
+            "mileslog must implement a custom slog.Handler")
+    require("runtime.CallersFrames" in mileslog and "record.PC" in mileslog,
+            "mileslog must extract source from record.PC")
+    require("MILES_LOG_LEVEL" in mileslog and "MILES_LOG_FILE" in mileslog
+            and "MILES_LOG_PAYLOADS" in mileslog,
+            "mileslog must read all logging env vars")
+    require("WithGroup" not in mileslog,
+            "mileslog must not use slog.WithGroup for category")
+    require("category" in mileslog and "MILES." in mileslog_test,
+            "mileslog tests must cover category formatting")
+
+    require("MILES_DEBUG_CHAT" not in main_go + provider_go,
+            "MILES_DEBUG_CHAT must be removed")
+    require("SetDebugLogging" not in provider_go,
+            "openai.SetDebugLogging must be removed")
+    require("debugf(" not in provider_go,
+            "provider debugf helper must be removed")
+    require("log.Printf" not in main_go + provider_go,
+            "sidecar must not use log.Printf")
+    require("log.Fatalf" not in main_go + provider_go,
+            "sidecar must not use log.Fatalf")
+    require("mileslog.New(\"MILES.SIDECAR\")" in main_go,
+            "main.go must use MILES.SIDECAR logger")
+    require("mileslog.New(\"MILES.CHAT.PROVIDER\")" in provider_go,
+            "provider.go must use MILES.CHAT.PROVIDER logger")
+
+    require("namespace MilesLogHandler" in qt_handler_h,
+            "Qt logging handler namespace must be declared")
+    require("void install()" in qt_handler_h,
+            "Qt logging handler must expose install()")
+    require("qInstallMessageHandler" in qt_handler_cpp,
+            "Qt logging handler must install a message handler")
+    require("qFormatLogMessage" in qt_handler_cpp,
+            "Qt logging handler must preserve default formatting for non-miles categories")
+    require("MILES_LOG_FILE" in qt_handler_cpp,
+            "Qt logging handler must support MILES_LOG_FILE")
+    require("miles.*" in qt_handler_cpp or "miles." in qt_handler_cpp,
+            "Qt logging handler must special-case miles.* categories")
+    require("MilesLogHandler::install()" in desktop_main,
+            "main.cpp must install the Qt logging handler")
+    require("LoggingFormatterSmoke" in desktop_cmake and "logging_formatter_smoke" in desktop_cmake,
+            "Qt logging formatter smoke test must be registered")
+    require("check_logging_standard" in root_cmake,
+            "root CMake must register check_logging_standard")
+
+    require("ForwardedErrorChannel" in chat_cpp,
+            "ChatController must forward sidecar stderr")
+    require("readyReadStandardError" not in chat_cpp,
+            "ChatController must not re-log sidecar stderr")
+    require("logProcessOutput" not in chat_cpp,
+            "ChatController logProcessOutput helper must be removed")
+    require("MILES_LOG_PAYLOADS" in chat_cpp,
+            "ChatController must forward MILES_LOG_PAYLOADS to sidecar")
+
+    print("logging standard contract ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_logging_standard.py
+++ b/tests/check_logging_standard.py
@@ -46,7 +46,9 @@ def main() -> int:
     require("MILES_LOG_LEVEL" in mileslog and "MILES_LOG_FILE" in mileslog
             and "MILES_LOG_PAYLOADS" in mileslog,
             "mileslog must read all logging env vars")
-    require("WithGroup" not in mileslog,
+    require("TextHandler" not in mileslog,
+            "mileslog must not use slog.TextHandler")
+    require(".WithGroup(" not in mileslog and "slog.WithGroup" not in mileslog,
             "mileslog must not use slog.WithGroup for category")
     require("category" in mileslog and "MILES." in mileslog_test,
             "mileslog tests must cover category formatting")

--- a/tests/check_phase_0_64_surface_menu_regressions.py
+++ b/tests/check_phase_0_64_surface_menu_regressions.py
@@ -32,6 +32,19 @@ def main() -> int:
         ".setStyleSheet(" not in menu_cpp and "QMenu {" not in menu_cpp,
         "右键菜单应使用 Qt 平台默认样式，不应写成自定义绘制菜单",
     )
+    require(
+        "QMenu menu(parent)" not in menu_cpp,
+        "跨 Space 桌宠窗口不应作为 QMenu 的 QWidget parent，否则 macOS 原生 popup 可能绑定到旧 Space 或崩溃",
+    )
+    require(
+        "QMenu menu;" in menu_cpp,
+        "右键菜单应使用无 QWidget parent 的 QMenu，避免依赖桌宠 native window 的 Space 状态",
+    )
+    require(
+        "showContextMenuQueued" in surface_cpp + surface_h
+        and "QTimer::singleShot(0" in surface_cpp,
+        "右键菜单不应在 mousePressEvent 中同步 exec，应排到当前鼠标事件之后显示",
+    )
 
     for forbidden in [
         "语音语言",

--- a/tests/check_phase_2_1_provider.py
+++ b/tests/check_phase_2_1_provider.py
@@ -71,7 +71,8 @@ def main() -> int:
     require("type ExpressionInfo struct" in provider_go, "ExpressionInfo struct must exist")
 
     require("m_holdBuffer" in controller_h, "ChatController must declare a hold buffer member")
-    require("flushHoldBuffer" in controller_h, "ChatController must declare flushHoldBuffer")
+    require("flushHoldBuffer" in controller_h or "drainHoldBufferToPacer" in controller_h,
+            "ChatController must declare a hold-buffer drain path")
     require("m_holdBuffer" in controller_cpp, "ChatController.cpp must use the hold buffer")
     require('"expressions"' in controller_cpp, "ChatController must include expressions field in request body")
 

--- a/tests/check_phase_2_1_provider.py
+++ b/tests/check_phase_2_1_provider.py
@@ -60,6 +60,10 @@ def main() -> int:
 
     require("openai.NewProvider" in main_go, "main must construct openai provider when configured")
     require("mock-fallback" in main_go, "main must label provider as mock-fallback when config missing")
+    require("MILES_DEBUG_CHAT" in main_go and "SetDebugLogging" in main_go,
+            "sidecar main must enable debug chat diagnostics from MILES_DEBUG_CHAT")
+    require("debugf(" in openai_go and "expression tag parsed" in openai_go,
+            "openai provider must log expression parser diagnostics in debug mode")
 
     require("http.MaxBytesReader" in server_go, "server must enforce max request body size")
     require("const DefaultListenAddr" in server_go or "DefaultListenAddr =" in server_go,

--- a/tests/check_phase_2_1_provider.py
+++ b/tests/check_phase_2_1_provider.py
@@ -60,10 +60,10 @@ def main() -> int:
 
     require("openai.NewProvider" in main_go, "main must construct openai provider when configured")
     require("mock-fallback" in main_go, "main must label provider as mock-fallback when config missing")
-    require("MILES_DEBUG_CHAT" in main_go and "SetDebugLogging" in main_go,
-            "sidecar main must enable debug chat diagnostics from MILES_DEBUG_CHAT")
-    require("debugf(" in openai_go and "expression tag parsed" in openai_go,
-            "openai provider must log expression parser diagnostics in debug mode")
+    require("mileslog.New(\"MILES.SIDECAR\")" in main_go and "MILES_LOG_LEVEL" not in main_go,
+            "sidecar main must use mileslog instead of direct debug env handling")
+    require("mileslog.New(\"MILES.CHAT.PROVIDER\")" in openai_go and "expression tag parsed" in openai_go,
+            "openai provider must log expression parser diagnostics through mileslog")
 
     require("http.MaxBytesReader" in server_go, "server must enforce max request body size")
     require("const DefaultListenAddr" in server_go or "DefaultListenAddr =" in server_go,

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -69,6 +69,8 @@ def main() -> int:
             "ChatController must call requestBoundaryAndNotify on PetRuntime")
     require("requestCleanFinishAndNotify" in controller_cpp,
             "ChatController must call requestCleanFinishAndNotify on PetRuntime")
+    require("chat expression requested" in controller_cpp and "qInfo" in controller_cpp,
+            "ChatController should log parsed expression events for provider-vs-runtime diagnosis")
 
     # PetRuntime API
     require("requestBoundaryAndNotify" in runtime_h,

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -75,8 +75,8 @@ def main() -> int:
     require("Q_LOGGING_CATEGORY" in controller_cpp and "miles.chat" in controller_cpp
             and "qCDebug" in controller_cpp,
             "ChatController should expose miles.chat debug logs for provider-vs-runtime diagnosis")
-    require("readyReadStandardError" in controller_cpp and "sidecar stderr" in controller_cpp,
-            "ChatController should forward sidecar stderr in debug logs")
+    require("ForwardedErrorChannel" in controller_cpp and "readyReadStandardError" not in controller_cpp,
+            "ChatController should forward sidecar stderr directly without re-logging it")
     require("sidecar health" in controller_cpp and '"pid"' in controller_cpp
             and "ownedPid" in controller_cpp,
             "ChatController should log sidecar health diagnostics and reject stale sidecar pids")

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -62,6 +62,8 @@ def main() -> int:
             "ChatController must handle PetRuntime boundaryReached callback")
     require("handleGateTimeout" in controller_h,
             "ChatController must handle GATED safety timeout")
+    require("m_finishPendingAfterStart" in controller_h and "m_finishPendingAfterStart = true" in controller_cpp,
+            "ChatController must preserve start expression when RUN_FINISHED arrives during BUFFERING_FOR_START")
     require("drainHoldBufferToPacer" in controller_h,
             "ChatController must drain its hold buffer through the pacer")
     require("appendChunkToCurrentMessage" in controller_h,
@@ -92,6 +94,8 @@ def main() -> int:
             "PetRuntime notify API must take std::function callbacks")
     require("drainPendingNotifications" in runtime_cpp,
             "PetRuntime must drain pending notifications at animation boundaries")
+    require("finishingPlaybackSerial" in runtime_cpp,
+            "PetRuntime must stop stale animation-finished flow when a boundary callback replaces the animation")
     require("miles.pet.runtime" in runtime_cpp and "miles.pet.expression" in runtime_cpp,
             "PetRuntime/ExpressionMapping should expose debug categories")
 

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Check the Phase 2.3.1 animation-text sync contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    file_path = ROOT / path
+    if not file_path.exists():
+        raise AssertionError(f"missing file: {path}")
+    return file_path.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    pacer_h = read("apps/desktop/src/chat/ChatTextPacer.h")
+    pacer_cpp = read("apps/desktop/src/chat/ChatTextPacer.cpp")
+    pacer_smoke = read("apps/desktop/tests/chat_text_pacer_smoke.cpp")
+    controller_h = read("apps/desktop/src/chat/ChatController.h")
+    controller_cpp = read("apps/desktop/src/chat/ChatController.cpp")
+    controller_smoke = read("apps/desktop/tests/chat_controller_smoke.cpp")
+    runtime_h = read("apps/desktop/src/pet/PetRuntime.h")
+    runtime_cpp = read("apps/desktop/src/pet/PetRuntime.cpp")
+    runtime_smoke = read("apps/desktop/tests/pet_runtime_smoke.cpp")
+    desktop_cmake = read("apps/desktop/CMakeLists.txt")
+    root_cmake = read("CMakeLists.txt")
+    stage_doc = read("docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md")
+    index_doc = read("docs/v2/文档索引.md")
+
+    # ChatTextPacer
+    require("class ChatTextPacer" in pacer_h, "ChatTextPacer class must exist")
+    require("void append(" in pacer_h, "ChatTextPacer must expose append()")
+    require("setMsPerChar" in pacer_h, "ChatTextPacer must expose setMsPerChar()")
+    require("msPerChar()" in pacer_h, "ChatTextPacer must expose msPerChar() getter")
+    require("pendingCount()" in pacer_h, "ChatTextPacer must expose pendingCount() for tests")
+    require("void chunkReady" in pacer_h, "ChatTextPacer must declare chunkReady signal")
+    require("QTimer" in pacer_cpp, "ChatTextPacer must drive emission with QTimer")
+    require("maxBacklog" in pacer_cpp.lower() or "backlog" in pacer_cpp.lower(),
+            "ChatTextPacer must implement backlog catch-up")
+
+    # ChatController state machine
+    require("enum class ChatPhase" in controller_h, "ChatController must declare ChatPhase enum")
+    require("IDLE" in controller_h and "BUFFERING_FOR_START" in controller_h
+            and "STREAMING" in controller_h and "GATED" in controller_h
+            and "WAITING_FOR_ANIMATION_END" in controller_h,
+            "ChatPhase must include all 5 design states")
+    require("ChatTextPacer" in controller_h, "ChatController must own a ChatTextPacer")
+    require("transitionTo" in controller_h, "ChatController must expose a transitionTo helper")
+    require("handleCleanFinishReady" in controller_h,
+            "ChatController must handle PetRuntime cleanFinishReady callback")
+    require("handleBoundaryReached" in controller_h,
+            "ChatController must handle PetRuntime boundaryReached callback")
+    require("handleGateTimeout" in controller_h,
+            "ChatController must handle GATED safety timeout")
+    require("drainHoldBufferToPacer" in controller_h,
+            "ChatController must drain its hold buffer through the pacer")
+    require("appendChunkToCurrentMessage" in controller_h,
+            "ChatController must append pacer chunks via a dedicated method")
+    require("requestBoundaryAndNotify" in controller_cpp,
+            "ChatController must call requestBoundaryAndNotify on PetRuntime")
+    require("requestCleanFinishAndNotify" in controller_cpp,
+            "ChatController must call requestCleanFinishAndNotify on PetRuntime")
+
+    # PetRuntime API
+    require("requestBoundaryAndNotify" in runtime_h,
+            "PetRuntime must declare requestBoundaryAndNotify")
+    require("requestCleanFinishAndNotify" in runtime_h,
+            "PetRuntime must declare requestCleanFinishAndNotify")
+    require("std::function" in runtime_h,
+            "PetRuntime notify API must take std::function callbacks")
+    require("drainPendingNotifications" in runtime_cpp,
+            "PetRuntime must drain pending notifications at animation boundaries")
+
+    # Tests
+    require("ChatTextPacer" in pacer_smoke,
+            "pacer smoke test must exercise ChatTextPacer")
+    require("msPerChar" in pacer_smoke,
+            "pacer smoke test must cover msPerChar")
+    require("backlog" in pacer_smoke.lower(),
+            "pacer smoke test must cover backlog catch-up")
+    require("BUFFERING_FOR_START" in controller_smoke
+            or "ChatPhase" in controller_smoke,
+            "controller smoke test must exercise the state machine")
+    require("GATED" in controller_smoke
+            or "expression switch" in controller_smoke.lower(),
+            "controller smoke test must exercise mid-run expression gating")
+    require("requestBoundaryAndNotify" in runtime_smoke,
+            "runtime smoke test must exercise requestBoundaryAndNotify")
+
+    # CMake
+    require("ChatTextPacer.cpp" in desktop_cmake,
+            "desktop CMake must list ChatTextPacer.cpp")
+    require("ChatTextPacerSmoke" in desktop_cmake,
+            "desktop CMake must register the ChatTextPacerSmoke target")
+    require("chat_text_pacer_smoke" in desktop_cmake,
+            "desktop CMake must register chat_text_pacer_smoke ctest")
+    require("check_phase_2_3_1_animation_sync" in root_cmake,
+            "root CMake must register the Phase 2.3.1 contract check")
+
+    # Docs
+    require("Phase 2.3.1" in stage_doc, "Phase 2.3.1 stage record must exist")
+    require("Phase 2.3.1" in index_doc, "doc index must link Phase 2.3.1 record")
+
+    print("phase 2.3.1 animation-text sync contract ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -31,6 +31,7 @@ def main() -> int:
     runtime_h = read("apps/desktop/src/pet/PetRuntime.h")
     runtime_cpp = read("apps/desktop/src/pet/PetRuntime.cpp")
     runtime_smoke = read("apps/desktop/tests/pet_runtime_smoke.cpp")
+    manifest = read("apps/desktop/resources/skins/miles-edgeworth/manifest.json")
     desktop_cmake = read("apps/desktop/CMakeLists.txt")
     root_cmake = read("CMakeLists.txt")
     stage_doc = read("docs/v2/阶段记录/Phase 2.3.1 动画-文字同步.md")
@@ -71,6 +72,10 @@ def main() -> int:
             "ChatController must call requestCleanFinishAndNotify on PetRuntime")
     require("chat expression requested" in controller_cpp and "qInfo" in controller_cpp,
             "ChatController should log parsed expression events for provider-vs-runtime diagnosis")
+    require('"action": "crossed", "allowedStates": ["speaking"]' in manifest,
+            "Miles manifest should map speaking neutral fallback to a visible speaking action")
+    require('"action": "idle_stand", "allowedStates": ["idle", "error"]' in manifest,
+            "Miles manifest should not map speaking neutral fallback to idle_stand")
 
     # PetRuntime API
     require("requestBoundaryAndNotify" in runtime_h,

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -44,7 +44,7 @@ def main() -> int:
     require("pendingCount()" in pacer_h, "ChatTextPacer must expose pendingCount() for tests")
     require("void chunkReady" in pacer_h, "ChatTextPacer must declare chunkReady signal")
     require("QTimer" in pacer_cpp, "ChatTextPacer must drive emission with QTimer")
-    require("maxBacklog" in pacer_cpp.lower() or "backlog" in pacer_cpp.lower(),
+    require("maxbacklog" in pacer_cpp.lower() or "backlog" in pacer_cpp.lower(),
             "ChatTextPacer must implement backlog catch-up")
 
     # ChatController state machine

--- a/tests/check_phase_2_3_1_animation_sync.py
+++ b/tests/check_phase_2_3_1_animation_sync.py
@@ -70,8 +70,14 @@ def main() -> int:
             "ChatController must call requestBoundaryAndNotify on PetRuntime")
     require("requestCleanFinishAndNotify" in controller_cpp,
             "ChatController must call requestCleanFinishAndNotify on PetRuntime")
-    require("chat expression requested" in controller_cpp and "qInfo" in controller_cpp,
-            "ChatController should log parsed expression events for provider-vs-runtime diagnosis")
+    require("Q_LOGGING_CATEGORY" in controller_cpp and "miles.chat" in controller_cpp
+            and "qCDebug" in controller_cpp,
+            "ChatController should expose miles.chat debug logs for provider-vs-runtime diagnosis")
+    require("readyReadStandardError" in controller_cpp and "sidecar stderr" in controller_cpp,
+            "ChatController should forward sidecar stderr in debug logs")
+    require("sidecar health" in controller_cpp and '"pid"' in controller_cpp
+            and "ownedPid" in controller_cpp,
+            "ChatController should log sidecar health diagnostics and reject stale sidecar pids")
     require('"action": "crossed", "allowedStates": ["speaking"]' in manifest,
             "Miles manifest should map speaking neutral fallback to a visible speaking action")
     require('"action": "idle_stand", "allowedStates": ["idle", "error"]' in manifest,
@@ -86,6 +92,8 @@ def main() -> int:
             "PetRuntime notify API must take std::function callbacks")
     require("drainPendingNotifications" in runtime_cpp,
             "PetRuntime must drain pending notifications at animation boundaries")
+    require("miles.pet.runtime" in runtime_cpp and "miles.pet.expression" in runtime_cpp,
+            "PetRuntime/ExpressionMapping should expose debug categories")
 
     # Tests
     require("ChatTextPacer" in pacer_smoke,


### PR DESCRIPTION
## 概要
- 新增 `ChatTextPacer` 和 ChatController 5 状态动画-文字同步状态机，支持首段等待、表达切换门控、回复结束动画边界、取消和错误兜底。
- PetRuntime 新增 boundary / cleanFinish callback API，并补阶段记录、契约检查和 smoke tests。
- 落地统一日志规范：Go `mileslog`、Qt `MilesLogHandler`、sidecar stderr 直通、`MILES_LOG_FILE` / `MILES_LOG_LEVEL` / `MILES_LOG_PAYLOADS`、payload 安全约束和日志格式契约。

## 验证
- `python3 tests/check_logging_standard.py && python3 tests/check_phase_2_1_provider.py && python3 tests/check_phase_2_2_settings.py && python3 tests/check_phase_2_3_1_animation_sync.py`
- `(cd apps/agent-core && go test ./...)`
- `cmake --build build --target MilesEdgeworthDesktop ChatControllerSmoke PetRuntimeSmoke LoggingFormatterSmoke`
- `ctest --test-dir build -R "check_logging_standard|logging_formatter_smoke|chat_controller_smoke|pet_runtime_smoke|settings_service_smoke" --output-on-failure`
- 运行时日志 smoke：`MILES_LOG_FILE=/tmp/miles-debug.log` 启动 app，确认文件日志生成、包含统一格式，且未出现 API key / Authorization / Bearer。
