### PR TITLE
fix: 修复聊天窗跨桌面空间显示

### DIFF
--- a/apps/desktop/qml/ChatBubbleWindow.qml
+++ b/apps/desktop/qml/ChatBubbleWindow.qml
@@ -150,6 +150,7 @@ ApplicationWindow {
         }
 
         visible = true
+        App.DesktopShell.prepareChatBubbleWindowForShow()
         raise()
 
         if (assistantPending === true) {

--- a/apps/desktop/qml/ChatBubbleWindow.qml
+++ b/apps/desktop/qml/ChatBubbleWindow.qml
@@ -151,7 +151,6 @@ ApplicationWindow {
 
         visible = true
         App.DesktopShell.prepareChatBubbleWindowForShow()
-        raise()
 
         if (assistantPending === true) {
             hideTimer.stop()

--- a/apps/desktop/qml/ChatWindow.qml
+++ b/apps/desktop/qml/ChatWindow.qml
@@ -91,8 +91,6 @@ ApplicationWindow {
         App.ChatController.loadConversations()
         show()
         App.DesktopShell.prepareChatWindowForOpen()
-        raise()
-        requestActivate()
         expandedComposer.forceInputFocus()
     }
 

--- a/apps/desktop/qml/ChatWindow.qml
+++ b/apps/desktop/qml/ChatWindow.qml
@@ -27,7 +27,6 @@ ApplicationWindow {
     readonly property int expandedTitleButtonInset: 11
 
     onVisibleChanged: {
-        App.DesktopShell.setChatWindowDockVisible(visible)
         syncShellChatState()
     }
 

--- a/apps/desktop/qml/ChatWindow.qml
+++ b/apps/desktop/qml/ChatWindow.qml
@@ -90,6 +90,7 @@ ApplicationWindow {
         showExpanded()
         App.ChatController.loadConversations()
         show()
+        App.DesktopShell.prepareChatWindowForOpen()
         raise()
         requestActivate()
         expandedComposer.forceInputFocus()

--- a/apps/desktop/src/DesktopShellController.cpp
+++ b/apps/desktop/src/DesktopShellController.cpp
@@ -289,15 +289,6 @@ void DesktopShellController::clearPetInputMask()
     WindowInputMaskController::clearMask(m_petWindow);
 }
 
-void DesktopShellController::setChatWindowDockVisible(bool visible)
-{
-#ifdef Q_OS_MACOS
-    setMacApplicationDockVisible(visible);
-#else
-    Q_UNUSED(visible);
-#endif
-}
-
 void DesktopShellController::setChatWindowExpanded(bool expanded)
 {
     if (m_chatWindowExpanded == expanded) {

--- a/apps/desktop/src/DesktopShellController.cpp
+++ b/apps/desktop/src/DesktopShellController.cpp
@@ -158,6 +158,26 @@ void DesktopShellController::setPetVisibleLocalBounds(const QRect &bounds)
     emit petWindowGeometryChanged();
 }
 
+void DesktopShellController::setChatWindow(QWindow *window)
+{
+    if (m_chatWindow == window) {
+        return;
+    }
+
+    m_chatWindow = window;
+    applyCompanionWindowBehavior(m_chatWindow);
+}
+
+void DesktopShellController::setChatBubbleWindow(QWindow *window)
+{
+    if (m_chatBubbleWindow == window) {
+        return;
+    }
+
+    m_chatBubbleWindow = window;
+    applyCompanionWindowBehavior(m_chatBubbleWindow);
+}
+
 void DesktopShellController::setAlwaysOnTop(bool alwaysOnTop)
 {
     if (m_alwaysOnTop == alwaysOnTop) {
@@ -288,6 +308,20 @@ void DesktopShellController::setChatWindowExpanded(bool expanded)
     emit chatWindowStateChanged();
 }
 
+void DesktopShellController::prepareChatWindowForOpen()
+{
+    if (m_chatWindow == nullptr) {
+        return;
+    }
+
+#ifdef Q_OS_MACOS
+    prepareMacCompanionWindowForOpen(m_chatWindow);
+#else
+    m_chatWindow->raise();
+    m_chatWindow->requestActivate();
+#endif
+}
+
 QVariantMap DesktopShellController::placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const
 {
     const QRect petGeometry = petVisibleScreenGeometry();
@@ -346,6 +380,19 @@ void DesktopShellController::applyCurrentLayerMode()
     // Windows/Linux 后续需要结合托盘和任务栏策略单独验证。
     m_petWindow->setFlag(Qt::WindowStaysOnTopHint, m_alwaysOnTop);
     m_petWindow->show();
+#endif
+}
+
+void DesktopShellController::applyCompanionWindowBehavior(QWindow *window)
+{
+    if (window == nullptr) {
+        return;
+    }
+
+#ifdef Q_OS_MACOS
+    applyMacCompanionWindowBehavior(window);
+#else
+    Q_UNUSED(window);
 #endif
 }
 

--- a/apps/desktop/src/DesktopShellController.cpp
+++ b/apps/desktop/src/DesktopShellController.cpp
@@ -313,6 +313,19 @@ void DesktopShellController::prepareChatWindowForOpen()
 #endif
 }
 
+void DesktopShellController::prepareChatBubbleWindowForShow()
+{
+    if (m_chatBubbleWindow == nullptr) {
+        return;
+    }
+
+#ifdef Q_OS_MACOS
+    prepareMacCompanionWindowForShow(m_chatBubbleWindow);
+#else
+    m_chatBubbleWindow->raise();
+#endif
+}
+
 QVariantMap DesktopShellController::placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const
 {
     const QRect petGeometry = petVisibleScreenGeometry();

--- a/apps/desktop/src/DesktopShellController.h
+++ b/apps/desktop/src/DesktopShellController.h
@@ -67,7 +67,6 @@ public slots:
     Q_INVOKABLE void movePetWindowTo(double x, double y);
     Q_INVOKABLE void setPetInputMask(const QUrl &animationUrl, double imageSize, double windowSize);
     Q_INVOKABLE void clearPetInputMask();
-    Q_INVOKABLE void setChatWindowDockVisible(bool visible);
     Q_INVOKABLE void setChatWindowExpanded(bool expanded);
     Q_INVOKABLE void prepareChatWindowForOpen();
     Q_INVOKABLE QVariantMap placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const;

--- a/apps/desktop/src/DesktopShellController.h
+++ b/apps/desktop/src/DesktopShellController.h
@@ -69,6 +69,7 @@ public slots:
     Q_INVOKABLE void clearPetInputMask();
     Q_INVOKABLE void setChatWindowExpanded(bool expanded);
     Q_INVOKABLE void prepareChatWindowForOpen();
+    Q_INVOKABLE void prepareChatBubbleWindowForShow();
     Q_INVOKABLE QVariantMap placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const;
 
 signals:

--- a/apps/desktop/src/DesktopShellController.h
+++ b/apps/desktop/src/DesktopShellController.h
@@ -53,6 +53,8 @@ public:
     bool chatWindowExpanded() const;
     void setPetWindow(QWindow *window);
     void setPetVisibleLocalBounds(const QRect &bounds);
+    void setChatWindow(QWindow *window);
+    void setChatBubbleWindow(QWindow *window);
 
 public slots:
     void setAlwaysOnTop(bool alwaysOnTop);
@@ -67,6 +69,7 @@ public slots:
     Q_INVOKABLE void clearPetInputMask();
     Q_INVOKABLE void setChatWindowDockVisible(bool visible);
     Q_INVOKABLE void setChatWindowExpanded(bool expanded);
+    Q_INVOKABLE void prepareChatWindowForOpen();
     Q_INVOKABLE QVariantMap placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const;
 
 signals:
@@ -79,6 +82,7 @@ signals:
 private:
     void createTrayIcon();
     void applyCurrentLayerMode();
+    void applyCompanionWindowBehavior(QWindow *window);
     QPointF legacyStartupPosition(double petScale) const;
     QRect petScreenAvailableGeometry() const;
     QRect petVisibleScreenGeometry() const;
@@ -86,6 +90,8 @@ private:
     QPointF clampedPetWindowPosition(const QPointF &candidatePosition) const;
 
     QWindow *m_petWindow = nullptr;
+    QWindow *m_chatWindow = nullptr;
+    QWindow *m_chatBubbleWindow = nullptr;
     QList<QMetaObject::Connection> m_petWindowGeometryConnections;
     QSystemTrayIcon *m_trayIcon = nullptr;
     QMenu *m_trayMenu = nullptr;

--- a/apps/desktop/src/main.cpp
+++ b/apps/desktop/src/main.cpp
@@ -68,6 +68,8 @@ int main(int argc, char *argv[])
     if (chatEngine.rootObjects().size() < 3) {
         return 1;
     }
+    // rootObjects follows the loadFromModule order above:
+    // 0 = ChatWindow, 1 = SettingsWindow, 2 = ChatBubbleWindow.
     auto *chatWindow = qobject_cast<QWindow *>(chatEngine.rootObjects().at(0));
     auto *chatBubbleWindow = qobject_cast<QWindow *>(chatEngine.rootObjects().at(2));
     if (chatWindow == nullptr || chatBubbleWindow == nullptr) {

--- a/apps/desktop/src/main.cpp
+++ b/apps/desktop/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     app.setQuitOnLastWindowClosed(false);
     QQuickStyle::setStyle("Basic");
 #ifdef Q_OS_MACOS
-    setMacApplicationDockVisible(false);
+    enterMacAccessoryMode();
 #endif
 
     DesktopShellController shellController;

--- a/apps/desktop/src/main.cpp
+++ b/apps/desktop/src/main.cpp
@@ -68,6 +68,13 @@ int main(int argc, char *argv[])
     if (chatEngine.rootObjects().size() < 3) {
         return 1;
     }
+    auto *chatWindow = qobject_cast<QWindow *>(chatEngine.rootObjects().at(0));
+    auto *chatBubbleWindow = qobject_cast<QWindow *>(chatEngine.rootObjects().at(2));
+    if (chatWindow == nullptr || chatBubbleWindow == nullptr) {
+        return 1;
+    }
+    shellController.setChatWindow(chatWindow);
+    shellController.setChatBubbleWindow(chatBubbleWindow);
     chatController.startSidecar();
 
     shellController.setPetScale(petRuntime.petScale());

--- a/apps/desktop/src/platform/MacPetWindowBehavior.h
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.h
@@ -35,7 +35,6 @@ void prepareMacCompanionWindowForOpen(QWindow *window);
 // 不让窗口成为 key window，避免桌宠回复气泡抢走用户当前输入焦点。
 void prepareMacCompanionWindowForShow(QWindow *window);
 
-// 调整整个应用的 Dock / activation policy。当前只在启动时进入 accessory
-// 模式；聊天窗显隐不能调用它，否则 macOS 会把全屏 Space 中的操作带回
-// 应用原来的桌面 Space。
-void setMacApplicationDockVisible(bool visible);
+// 启动时进入 accessory 模式。聊天窗显隐不能切回普通 Regular app，
+// 否则 macOS 会把全屏 Space 中的操作带回应用原来的桌面 Space。
+void enterMacAccessoryMode();

--- a/apps/desktop/src/platform/MacPetWindowBehavior.h
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.h
@@ -31,6 +31,7 @@ void applyMacCompanionWindowBehavior(QWindow *window);
 // 当前 Space 的前台窗口栈。
 void prepareMacCompanionWindowForOpen(QWindow *window);
 
-// 聊天窗口是普通工作窗口，打开时应让应用显示在 Dock；关闭后恢复桌宠
-// 辅助应用模式，避免只剩桌宠本体时占用普通应用位置。
+// 调整整个应用的 Dock / activation policy。当前只在启动时进入 accessory
+// 模式；聊天窗显隐不能调用它，否则 macOS 会把全屏 Space 中的操作带回
+// 应用原来的桌面 Space。
 void setMacApplicationDockVisible(bool visible);

--- a/apps/desktop/src/platform/MacPetWindowBehavior.h
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.h
@@ -22,6 +22,15 @@ void setMacPetWindowAlwaysOnTop(QWindow *window, bool alwaysOnTop);
 // Space 成为可接收菜单的前台上下文。
 void prepareMacPetWindowForContextMenu(QWindow *window);
 
+// 聊天窗和桌宠回复气泡不是桌宠本体，但用户会从桌宠所在的当前 Space
+// 打开它们。它们需要和桌宠一样加入所有 Space，并允许显示在全屏应用上方，
+// 否则在桌宠跟随到全屏 Space 后，聊天 UI 会留在原来的桌面 Space。
+void applyMacCompanionWindowBehavior(QWindow *window);
+
+// 打开聊天窗前调用：确保 native 窗口已经具备 companion 行为，并进入
+// 当前 Space 的前台窗口栈。
+void prepareMacCompanionWindowForOpen(QWindow *window);
+
 // 聊天窗口是普通工作窗口，打开时应让应用显示在 Dock；关闭后恢复桌宠
 // 辅助应用模式，避免只剩桌宠本体时占用普通应用位置。
 void setMacApplicationDockVisible(bool visible);

--- a/apps/desktop/src/platform/MacPetWindowBehavior.h
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.h
@@ -31,6 +31,10 @@ void applyMacCompanionWindowBehavior(QWindow *window);
 // 当前 Space 的前台窗口栈。
 void prepareMacCompanionWindowForOpen(QWindow *window);
 
+// 显示非输入型 companion 窗口前调用。它只重新应用层级并前置窗口，
+// 不让窗口成为 key window，避免桌宠回复气泡抢走用户当前输入焦点。
+void prepareMacCompanionWindowForShow(QWindow *window);
+
 // 调整整个应用的 Dock / activation policy。当前只在启动时进入 accessory
 // 模式；聊天窗显隐不能调用它，否则 macOS 会把全屏 Space 中的操作带回
 // 应用原来的桌面 Space。

--- a/apps/desktop/src/platform/MacPetWindowBehavior.mm
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.mm
@@ -153,7 +153,7 @@ void prepareMacCompanionWindowForShow(QWindow *window)
     [nativeWindow orderFrontRegardless];
 }
 
-void setMacApplicationDockVisible(bool visible)
+void enterMacAccessoryMode()
 {
-    [NSApp setActivationPolicy:visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
 }

--- a/apps/desktop/src/platform/MacPetWindowBehavior.mm
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.mm
@@ -111,7 +111,6 @@ void prepareMacPetWindowForContextMenu(QWindow *window)
     }
 
     [nativeWindow orderFrontRegardless];
-    [NSApp activateIgnoringOtherApps:YES];
 }
 
 void applyMacCompanionWindowBehavior(QWindow *window)
@@ -140,13 +139,10 @@ void prepareMacCompanionWindowForOpen(QWindow *window)
 
     applyMacCompanionWindowBehavior(window);
     [nativeWindow orderFrontRegardless];
-    [NSApp activateIgnoringOtherApps:YES];
+    [nativeWindow makeKeyAndOrderFront:nil];
 }
 
 void setMacApplicationDockVisible(bool visible)
 {
     [NSApp setActivationPolicy:visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];
-    if (visible) {
-        [NSApp activateIgnoringOtherApps:YES];
-    }
 }

--- a/apps/desktop/src/platform/MacPetWindowBehavior.mm
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.mm
@@ -142,6 +142,17 @@ void prepareMacCompanionWindowForOpen(QWindow *window)
     [nativeWindow makeKeyAndOrderFront:nil];
 }
 
+void prepareMacCompanionWindowForShow(QWindow *window)
+{
+    NSWindow *nativeWindow = nativeWindowForQWindow(window);
+    if (nativeWindow == nil) {
+        return;
+    }
+
+    applyMacCompanionWindowBehavior(window);
+    [nativeWindow orderFrontRegardless];
+}
+
 void setMacApplicationDockVisible(bool visible)
 {
     [NSApp setActivationPolicy:visible ? NSApplicationActivationPolicyRegular : NSApplicationActivationPolicyAccessory];

--- a/apps/desktop/src/platform/MacPetWindowBehavior.mm
+++ b/apps/desktop/src/platform/MacPetWindowBehavior.mm
@@ -35,6 +35,19 @@ NSWindowCollectionBehavior baseCollectionBehavior(NSWindow *window)
                 | NSWindowCollectionBehaviorFullScreenDisallowsTiling;
     return behavior;
 }
+
+NSWindowCollectionBehavior companionCollectionBehavior(NSWindow *window)
+{
+    NSWindowCollectionBehavior behavior = baseCollectionBehavior(window);
+    behavior &= ~NSWindowCollectionBehaviorMoveToActiveSpace;
+    behavior |= NSWindowCollectionBehaviorCanJoinAllSpaces
+                | NSWindowCollectionBehaviorStationary
+                | NSWindowCollectionBehaviorFullScreenAuxiliary;
+    if (@available(macOS 13.0, *)) {
+        behavior |= NSWindowCollectionBehaviorCanJoinAllApplications;
+    }
+    return behavior;
+}
 }
 
 void applyMacPetWindowBaseBehavior(QWindow *window)
@@ -97,6 +110,35 @@ void prepareMacPetWindowForContextMenu(QWindow *window)
         return;
     }
 
+    [nativeWindow orderFrontRegardless];
+    [NSApp activateIgnoringOtherApps:YES];
+}
+
+void applyMacCompanionWindowBehavior(QWindow *window)
+{
+    NSWindow *nativeWindow = nativeWindowForQWindow(window);
+    if (nativeWindow == nil) {
+        return;
+    }
+
+    [nativeWindow setHidesOnDeactivate:NO];
+    [nativeWindow setCanHide:NO];
+    [nativeWindow setRestorable:NO];
+    [nativeWindow setOpaque:NO];
+    [nativeWindow setBackgroundColor:[NSColor clearColor]];
+    [nativeWindow setAnimationBehavior:NSWindowAnimationBehaviorNone];
+    [nativeWindow setCollectionBehavior:companionCollectionBehavior(nativeWindow)];
+    [nativeWindow setLevel:CGWindowLevelForKey(kCGScreenSaverWindowLevelKey)];
+}
+
+void prepareMacCompanionWindowForOpen(QWindow *window)
+{
+    NSWindow *nativeWindow = nativeWindowForQWindow(window);
+    if (nativeWindow == nil) {
+        return;
+    }
+
+    applyMacCompanionWindowBehavior(window);
     [nativeWindow orderFrontRegardless];
     [NSApp activateIgnoringOtherApps:YES];
 }

--- a/docs/v2/参考资料/技术债务与评审待办.md
+++ b/docs/v2/参考资料/技术债务与评审待办.md
@@ -18,11 +18,11 @@
 
 ### [Runtime/Platform] macOS Space 下的窗口策略仍需集中设计
 
-Phase 2.3.1 曾通过 `prepareMacPetWindowForContextMenu()` 里的 macOS 特定激活逻辑修复切换桌面空间后的菜单问题。后续 UI 优化发现主动 `activateIgnoringOtherApps` 会把全屏 Space 中的桌宠操作带回应用原来的桌面 Space；当前实现已改为只调整 native window 的 order/key 状态，聊天窗和迷你态气泡使用 companion window 行为跟随桌宠进入所有 Space / 全屏辅助层级。
+Phase 2.3.1 曾通过 `prepareMacPetWindowForContextMenu()` 里的 macOS 特定激活逻辑修复切换桌面空间后的菜单问题。后续 UI 优化发现主动 `activateIgnoringOtherApps`、以及聊天窗显隐时切换 `NSApplicationActivationPolicy`，都会把全屏 Space 中的桌宠操作带回应用原来的桌面 Space；当前实现只在启动时进入 accessory 模式，聊天窗和迷你态气泡使用 companion window 行为跟随桌宠进入所有 Space / 全屏辅助层级。
 
 后续如果继续扩展 macOS window/Space 行为，需要评估：
 
-- 上下文菜单、桌宠置顶、聊天窗 dock 行为是否需要统一的 macOS window policy 文档。
+- 上下文菜单、桌宠置顶、聊天窗 companion 行为是否需要统一的 macOS window policy 文档。
 - 该逻辑是否需要独立平台 smoke 或手动验收脚本。
 
 ## 设置与皮肤热重载待办

--- a/docs/v2/参考资料/技术债务与评审待办.md
+++ b/docs/v2/参考资料/技术债务与评审待办.md
@@ -16,13 +16,12 @@
 
 后续如果继续扩展 TTS、唇形同步或更复杂的 action policy，应新开独立阶段记录，不复用 Phase 2.4 的待办。
 
-### [Runtime/Platform] macOS Space 下的上下文菜单实现需后续清理
+### [Runtime/Platform] macOS Space 下的窗口策略仍需集中设计
 
-Phase 2.3.1 修复了切换桌面空间后右键菜单和窗口生命周期问题，目前依赖 `prepareMacPetWindowForContextMenu()` 里的 macOS 特定激活逻辑。该实现解决了当前崩溃和菜单不显示问题，但仍属于平台适配代码。
+Phase 2.3.1 曾通过 `prepareMacPetWindowForContextMenu()` 里的 macOS 特定激活逻辑修复切换桌面空间后的菜单问题。后续 UI 优化发现主动 `activateIgnoringOtherApps` 会把全屏 Space 中的桌宠操作带回应用原来的桌面 Space；当前实现已改为只调整 native window 的 order/key 状态，聊天窗和迷你态气泡使用 companion window 行为跟随桌宠进入所有 Space / 全屏辅助层级。
 
 后续如果继续扩展 macOS window/Space 行为，需要评估：
 
-- 是否有更现代的 AppKit API 可替代当前激活方式。
 - 上下文菜单、桌宠置顶、聊天窗 dock 行为是否需要统一的 macOS window policy 文档。
 - 该逻辑是否需要独立平台 smoke 或手动验收脚本。
 

--- a/docs/v2/设计方案/桌宠运行时与动画调度设计.md
+++ b/docs/v2/设计方案/桌宠运行时与动画调度设计.md
@@ -911,7 +911,7 @@ Phase 0 / 1 已实现必要桌宠运行时能力：
 
 Phase 2.0 已实现 AI 聊天最小闭环：
 
-- QML `ChatWindow`、Dock 激活策略，以及 macOS companion window 层级；聊天窗和迷你态气泡需要跟随桌宠进入所有 Space / 全屏辅助窗口层级。
+- QML `ChatWindow` 和 macOS companion window 层级；聊天窗和迷你态气泡需要跟随桌宠进入所有 Space / 全屏辅助窗口层级。聊天窗显隐不切换 `NSApplicationActivationPolicy`，应用保持 accessory 模式，避免全屏 Space 操作被带回应用原桌面。
 - C++ `ChatController` 启动并连接 Go sidecar。
 - Go mock provider 通过 SSE 输出聊天事件。
 - `thinking` / `speaking` / `error` 语义事件接入 `PetRuntime::requestExpression(...)`。

--- a/docs/v2/设计方案/桌宠运行时与动画调度设计.md
+++ b/docs/v2/设计方案/桌宠运行时与动画调度设计.md
@@ -911,7 +911,7 @@ Phase 0 / 1 已实现必要桌宠运行时能力：
 
 Phase 2.0 已实现 AI 聊天最小闭环：
 
-- QML `ChatWindow` 和 Dock 激活策略。
+- QML `ChatWindow`、Dock 激活策略，以及 macOS companion window 层级；聊天窗和迷你态气泡需要跟随桌宠进入所有 Space / 全屏辅助窗口层级。
 - C++ `ChatController` 启动并连接 Go sidecar。
 - Go mock provider 通过 SSE 输出聊天事件。
 - `thinking` / `speaking` / `error` 语义事件接入 `PetRuntime::requestExpression(...)`。

--- a/docs/v2/阶段记录/Phase 2.0 AI Chat MVP 骨架.md
+++ b/docs/v2/阶段记录/Phase 2.0 AI Chat MVP 骨架.md
@@ -26,7 +26,7 @@ ctest --test-dir build -R "chat_stream_event_parser_smoke|chat_controller_smoke|
 ## 当前限制
 
 - 只有 mock provider，不读取 API key，不访问外部模型服务。
-- ChatWindow 仍是独立窗口；桌宠本体保持原生 QWidget `PetSurfaceWindow`。后续 UI 优化已补齐 macOS companion window 行为，聊天窗和迷你态气泡会加入所有 Space 并允许显示在全屏应用上方。
+- ChatWindow 仍是独立窗口；桌宠本体保持原生 QWidget `PetSurfaceWindow`。后续 UI 优化已补齐 macOS companion window 行为，聊天窗和迷你态气泡会加入所有 Space 并允许显示在全屏应用上方；聊天窗显隐不再切换应用 Dock / activation policy。
 - 会话不持久化，重启后不保留历史。
 - expression 只覆盖 Phase 2.0 的 thinking、speaking、idle、error 最小状态链路。
 - Go 已成为当前根 CMake 构建的前置条件。

--- a/docs/v2/阶段记录/Phase 2.0 AI Chat MVP 骨架.md
+++ b/docs/v2/阶段记录/Phase 2.0 AI Chat MVP 骨架.md
@@ -26,7 +26,7 @@ ctest --test-dir build -R "chat_stream_event_parser_smoke|chat_controller_smoke|
 ## 当前限制
 
 - 只有 mock provider，不读取 API key，不访问外部模型服务。
-- ChatWindow 是独立普通窗口；桌宠本体仍保持原生 QWidget `PetSurfaceWindow`。
+- ChatWindow 仍是独立窗口；桌宠本体保持原生 QWidget `PetSurfaceWindow`。后续 UI 优化已补齐 macOS companion window 行为，聊天窗和迷你态气泡会加入所有 Space 并允许显示在全屏应用上方。
 - 会话不持久化，重启后不保留历史。
 - expression 只覆盖 Phase 2.0 的 thinking、speaking、idle、error 最小状态链路。
 - Go 已成为当前根 CMake 构建的前置条件。

--- a/tests/check_macos_window_behavior.py
+++ b/tests/check_macos_window_behavior.py
@@ -19,6 +19,9 @@ MAC_BEHAVIOR_H = ROOT / "apps/desktop/src/platform/MacPetWindowBehavior.h"
 PET_WINDOW_QML = ROOT / "apps/desktop/qml/PetWindow.qml"
 DESKTOP_CMAKE = ROOT / "apps/desktop/CMakeLists.txt"
 MAIN_CPP = ROOT / "apps/desktop/src/main.cpp"
+CHAT_WINDOW_QML = ROOT / "apps/desktop/qml/ChatWindow.qml"
+SHELL_CONTROLLER_H = ROOT / "apps/desktop/src/DesktopShellController.h"
+SHELL_CONTROLLER_CPP = ROOT / "apps/desktop/src/DesktopShellController.cpp"
 
 
 def extract_function(source: str, name: str) -> str:
@@ -95,6 +98,8 @@ def main() -> int:
 
     cmake_source = DESKTOP_CMAKE.read_text(encoding="utf-8")
     main_source = MAIN_CPP.read_text(encoding="utf-8")
+    chat_window_source = CHAT_WINDOW_QML.read_text(encoding="utf-8")
+    shell_source = SHELL_CONTROLLER_H.read_text(encoding="utf-8") + SHELL_CONTROLLER_CPP.read_text(encoding="utf-8")
     if "Widgets" not in cmake_source or "Qt6::Widgets" not in cmake_source:
         print("Qt.labs.platform 菜单需要链接 Qt Widgets 作为平台菜单兼容层。", file=sys.stderr)
         return 1
@@ -114,6 +119,21 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+    if "App.DesktopShell.setChatWindowDockVisible" in chat_window_source:
+        print(
+            "聊天窗显示/隐藏不应切换 NSApplicationActivationPolicy；否则会把全屏 Space 操作带回应用原桌面。",
+            file=sys.stderr,
+        )
+        return 1
+    if "setChatWindowDockVisible" in shell_source:
+        print(
+            "DesktopShellController 不应再暴露聊天窗 Dock 可见性入口；聊天窗应作为 companion window 跟随桌宠。",
+            file=sys.stderr,
+        )
+        return 1
+    if "MILES_DIAG_SKIP_CHAT_DOCK_POLICY" in source or "MILES_SPACES" in source + chat_window_source + shell_source:
+        print("macOS Space 调试开关和临时日志不应进入正式实现。", file=sys.stderr)
+        return 1
     if "makeKeyAndOrderFront" not in companion_open_body:
         print("聊天窗打开时应让 companion window 自身成为 key window，而不是激活整个应用。", file=sys.stderr)
         return 1

--- a/tests/check_macos_window_behavior.py
+++ b/tests/check_macos_window_behavior.py
@@ -52,7 +52,7 @@ def main() -> int:
     function_body = extract_function(source, "setMacPetWindowAlwaysOnTop")
     context_menu_body = extract_function(source, "prepareMacPetWindowForContextMenu")
     companion_open_body = extract_function(source, "prepareMacCompanionWindowForOpen")
-    dock_body = extract_function(source, "setMacApplicationDockVisible")
+    accessory_body = extract_function(source, "enterMacAccessoryMode")
 
     forbidden_tokens = [
         "moveWindowToStationarySkyLightSpace",
@@ -110,7 +110,7 @@ def main() -> int:
     activating_functions = {
         "prepareMacPetWindowForContextMenu": context_menu_body,
         "prepareMacCompanionWindowForOpen": companion_open_body,
-        "setMacApplicationDockVisible": dock_body,
+        "enterMacAccessoryMode": accessory_body,
     }
     for name, body in activating_functions.items():
         if "activateIgnoringOtherApps" in body:
@@ -133,6 +133,9 @@ def main() -> int:
         return 1
     if "MILES_DIAG_SKIP_CHAT_DOCK_POLICY" in source or "MILES_SPACES" in source + chat_window_source + shell_source:
         print("macOS Space 调试开关和临时日志不应进入正式实现。", file=sys.stderr)
+        return 1
+    if "NSApplicationActivationPolicyRegular" in source + header:
+        print("桌宠应用不应再暴露切回 Regular activation policy 的平台路径。", file=sys.stderr)
         return 1
     if "makeKeyAndOrderFront" not in companion_open_body:
         print("聊天窗打开时应让 companion window 自身成为 key window，而不是激活整个应用。", file=sys.stderr)

--- a/tests/check_macos_window_behavior.py
+++ b/tests/check_macos_window_behavior.py
@@ -15,6 +15,7 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 MAC_BEHAVIOR = ROOT / "apps/desktop/src/platform/MacPetWindowBehavior.mm"
+MAC_BEHAVIOR_H = ROOT / "apps/desktop/src/platform/MacPetWindowBehavior.h"
 PET_WINDOW_QML = ROOT / "apps/desktop/qml/PetWindow.qml"
 DESKTOP_CMAKE = ROOT / "apps/desktop/CMakeLists.txt"
 MAIN_CPP = ROOT / "apps/desktop/src/main.cpp"
@@ -44,6 +45,7 @@ def extract_function(source: str, name: str) -> str:
 
 def main() -> int:
     source = MAC_BEHAVIOR.read_text(encoding="utf-8")
+    header = MAC_BEHAVIOR_H.read_text(encoding="utf-8")
     function_body = extract_function(source, "setMacPetWindowAlwaysOnTop")
 
     forbidden_tokens = [
@@ -95,6 +97,25 @@ def main() -> int:
         return 1
     if "QApplication" not in main_source or "QGuiApplication app" in main_source:
         print("Qt.labs.platform 菜单应使用 QApplication，而不是纯 QGuiApplication。", file=sys.stderr)
+        return 1
+
+    companion_required_tokens = [
+        "applyMacCompanionWindowBehavior(QWindow *window)",
+        "prepareMacCompanionWindowForOpen(QWindow *window)",
+        "NSWindowCollectionBehaviorCanJoinAllSpaces",
+        "NSWindowCollectionBehaviorFullScreenAuxiliary",
+        "NSWindowCollectionBehaviorStationary",
+        "kCGScreenSaverWindowLevelKey",
+        "orderFrontRegardless",
+        "activateIgnoringOtherApps:YES",
+    ]
+    missing_companion_tokens = [
+        token for token in companion_required_tokens
+        if token not in source + header
+    ]
+    if missing_companion_tokens:
+        joined = ", ".join(missing_companion_tokens)
+        print(f"聊天/气泡窗口缺少跨 Space 全屏辅助窗口行为：{joined}", file=sys.stderr)
         return 1
 
     return 0

--- a/tests/check_macos_window_behavior.py
+++ b/tests/check_macos_window_behavior.py
@@ -47,6 +47,9 @@ def main() -> int:
     source = MAC_BEHAVIOR.read_text(encoding="utf-8")
     header = MAC_BEHAVIOR_H.read_text(encoding="utf-8")
     function_body = extract_function(source, "setMacPetWindowAlwaysOnTop")
+    context_menu_body = extract_function(source, "prepareMacPetWindowForContextMenu")
+    companion_open_body = extract_function(source, "prepareMacCompanionWindowForOpen")
+    dock_body = extract_function(source, "setMacApplicationDockVisible")
 
     forbidden_tokens = [
         "moveWindowToStationarySkyLightSpace",
@@ -99,6 +102,22 @@ def main() -> int:
         print("Qt.labs.platform 菜单应使用 QApplication，而不是纯 QGuiApplication。", file=sys.stderr)
         return 1
 
+    activating_functions = {
+        "prepareMacPetWindowForContextMenu": context_menu_body,
+        "prepareMacCompanionWindowForOpen": companion_open_body,
+        "setMacApplicationDockVisible": dock_body,
+    }
+    for name, body in activating_functions.items():
+        if "activateIgnoringOtherApps" in body:
+            print(
+                f"{name} 不应主动激活应用；否则会把全屏 Space 中的桌宠操作带回原桌面 Space。",
+                file=sys.stderr,
+            )
+            return 1
+    if "makeKeyAndOrderFront" not in companion_open_body:
+        print("聊天窗打开时应让 companion window 自身成为 key window，而不是激活整个应用。", file=sys.stderr)
+        return 1
+
     companion_required_tokens = [
         "applyMacCompanionWindowBehavior(QWindow *window)",
         "prepareMacCompanionWindowForOpen(QWindow *window)",
@@ -107,7 +126,7 @@ def main() -> int:
         "NSWindowCollectionBehaviorStationary",
         "kCGScreenSaverWindowLevelKey",
         "orderFrontRegardless",
-        "activateIgnoringOtherApps:YES",
+        "makeKeyAndOrderFront",
     ]
     missing_companion_tokens = [
         token for token in companion_required_tokens

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -129,6 +129,10 @@ def main() -> int:
         "ChatWindow open path must prepare the native window before activation",
     )
     require(
+        "requestActivate()" not in chat_qml,
+        "ChatWindow QML must not request app activation directly because it can switch macOS Spaces",
+    )
+    require(
         "setMacApplicationDockVisible(visible)" in shell_cpp,
         "DesktopShellController must delegate chat Dock visibility to macOS platform code",
     )

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -136,7 +136,7 @@ def main() -> int:
         "macOS platform layer must expose companion behavior for chat windows",
     )
     require(
-        "setMacApplicationDockVisible(bool visible)" in mac_behavior_h + mac_behavior_mm,
+        "enterMacAccessoryMode()" in mac_behavior_h + mac_behavior_mm,
         "macOS platform layer must expose startup application activation policy control",
     )
     require(
@@ -144,7 +144,11 @@ def main() -> int:
         "macOS app must be able to start in accessory activation policy",
     )
     require(
-        "setMacApplicationDockVisible(false)" in main_cpp,
+        "NSApplicationActivationPolicyRegular" not in mac_behavior_h + mac_behavior_mm,
+        "macOS platform layer must not keep a public path back to Regular activation policy",
+    )
+    require(
+        "enterMacAccessoryMode()" in main_cpp,
         "main must start macOS in accessory mode; chat visibility must not change activation policy",
     )
     require("loadFromModule(\"MilesEdgeworth\", \"ChatWindow\")" in main_cpp, "main must load ChatWindow QML")

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -114,8 +114,28 @@ def main() -> int:
         "DesktopShellController must expose chat Dock visibility control",
     )
     require(
+        "setChatWindow(QWindow *window)" in shell_h + shell_cpp
+        and "m_chatWindow" in shell_h + shell_cpp,
+        "DesktopShellController must retain the ChatWindow QWindow for macOS Space behavior",
+    )
+    require(
+        "setChatBubbleWindow(QWindow *window)" in shell_h + shell_cpp
+        and "m_chatBubbleWindow" in shell_h + shell_cpp,
+        "DesktopShellController must retain the ChatBubbleWindow QWindow for macOS Space behavior",
+    )
+    require(
+        "prepareChatWindowForOpen()" in shell_h + shell_cpp
+        and "App.DesktopShell.prepareChatWindowForOpen()" in chat_qml,
+        "ChatWindow open path must prepare the native window before activation",
+    )
+    require(
         "setMacApplicationDockVisible(visible)" in shell_cpp,
         "DesktopShellController must delegate chat Dock visibility to macOS platform code",
+    )
+    require(
+        "applyMacCompanionWindowBehavior" in shell_cpp + mac_behavior_h + mac_behavior_mm
+        and "prepareMacCompanionWindowForOpen" in shell_cpp + mac_behavior_h + mac_behavior_mm,
+        "macOS platform layer must expose companion behavior for chat windows",
     )
     require(
         "setMacApplicationDockVisible(bool visible)" in mac_behavior_h + mac_behavior_mm,
@@ -131,6 +151,16 @@ def main() -> int:
         "main must start macOS in accessory mode until the chat window is visible",
     )
     require("loadFromModule(\"MilesEdgeworth\", \"ChatWindow\")" in main_cpp, "main must load ChatWindow QML")
+    require(
+        "qobject_cast<QWindow *>(chatEngine.rootObjects().at(0))" in main_cpp
+        and "shellController.setChatWindow(chatWindow)" in main_cpp,
+        "main must register ChatWindow with DesktopShellController",
+    )
+    require(
+        "qobject_cast<QWindow *>(chatEngine.rootObjects().at(2))" in main_cpp
+        and "shellController.setChatBubbleWindow(chatBubbleWindow)" in main_cpp,
+        "main must register ChatBubbleWindow with DesktopShellController",
+    )
     require("聊天" in menu_cpp, "native pet context menu must include chat entry")
     require('"error"' in manifest, "Miles manifest must expose error state for chat failures")
     require('"recipe": "thinking.holdUntilCancelled", "allowedStates": ["thinking"]' in manifest,

--- a/tests/check_phase_2_0_ai_chat_mvp.py
+++ b/tests/check_phase_2_0_ai_chat_mvp.py
@@ -84,10 +84,10 @@ def main() -> int:
     require("import QtQuick.Controls" in chat_qml, "ChatWindow must use Qt Quick Controls")
     require("App.ChatController.sendMessage" in chat_qml, "ChatWindow must send through ChatController")
     require("onOpenWindowRequested" in chat_qml, "ChatWindow must react to controller open signal")
-    require("flags: Qt.Window" in chat_qml, "ChatWindow must be a normal dock/taskbar window")
+    require("flags: Qt.Window" in chat_qml, "ChatWindow must be a top-level Qt window")
     require(
-        "App.DesktopShell.setChatWindowDockVisible(visible)" in chat_qml,
-        "ChatWindow visibility must control macOS Dock presence",
+        "App.DesktopShell.setChatWindowDockVisible" not in chat_qml,
+        "ChatWindow visibility must not switch macOS activation policy because it can move Spaces",
     )
     require("id: compactComposer" in chat_qml, "ChatWindow composer must be addressable by id")
     require(
@@ -109,10 +109,8 @@ def main() -> int:
         'QQuickStyle::setStyle("Basic")' in main_cpp,
         "main must use a customizable Qt Quick Controls style before loading ChatWindow",
     )
-    require(
-        "setChatWindowDockVisible(bool visible)" in shell_h + shell_cpp,
-        "DesktopShellController must expose chat Dock visibility control",
-    )
+    require("setChatWindowDockVisible" not in shell_h + shell_cpp,
+            "DesktopShellController must not expose chat Dock visibility control")
     require(
         "setChatWindow(QWindow *window)" in shell_h + shell_cpp
         and "m_chatWindow" in shell_h + shell_cpp,
@@ -133,26 +131,21 @@ def main() -> int:
         "ChatWindow QML must not request app activation directly because it can switch macOS Spaces",
     )
     require(
-        "setMacApplicationDockVisible(visible)" in shell_cpp,
-        "DesktopShellController must delegate chat Dock visibility to macOS platform code",
-    )
-    require(
         "applyMacCompanionWindowBehavior" in shell_cpp + mac_behavior_h + mac_behavior_mm
         and "prepareMacCompanionWindowForOpen" in shell_cpp + mac_behavior_h + mac_behavior_mm,
         "macOS platform layer must expose companion behavior for chat windows",
     )
     require(
         "setMacApplicationDockVisible(bool visible)" in mac_behavior_h + mac_behavior_mm,
-        "macOS platform layer must expose application Dock visibility control",
+        "macOS platform layer must expose startup application activation policy control",
     )
     require(
-        "NSApplicationActivationPolicyRegular" in mac_behavior_mm
-        and "NSApplicationActivationPolicyAccessory" in mac_behavior_mm,
-        "macOS chat Dock control must switch between Regular and Accessory activation policies",
+        "NSApplicationActivationPolicyAccessory" in mac_behavior_mm,
+        "macOS app must be able to start in accessory activation policy",
     )
     require(
         "setMacApplicationDockVisible(false)" in main_cpp,
-        "main must start macOS in accessory mode until the chat window is visible",
+        "main must start macOS in accessory mode; chat visibility must not change activation policy",
     )
     require("loadFromModule(\"MilesEdgeworth\", \"ChatWindow\")" in main_cpp, "main must load ChatWindow QML")
     require(

--- a/tests/check_phase_2_4_chat_compact_bubble.py
+++ b/tests/check_phase_2_4_chat_compact_bubble.py
@@ -172,6 +172,10 @@ def main() -> int:
         "makeKeyAndOrderFront" not in companion_show_body,
         "bubble companion show path should re-apply and order front without stealing key focus",
     )
+    require(
+        "App.DesktopShell.prepareChatBubbleWindowForShow()\n        raise()" not in bubble_qml,
+        "ChatBubbleWindow should not call QML raise immediately after prepareChatBubbleWindowForShow",
+    )
 
     for token in [
         "PetVisibleBounds.cpp",

--- a/tests/check_phase_2_4_chat_compact_bubble.py
+++ b/tests/check_phase_2_4_chat_compact_bubble.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -21,6 +22,26 @@ def require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
+def extract_function(source: str, name: str) -> str:
+    match = re.search(rf"\b{name}\s*\([^)]*\)\s*\{{", source)
+    if match is None:
+        raise AssertionError(f"missing function: {name}")
+
+    index = match.end() - 1
+    depth = 0
+    while index < len(source):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[match.start() : index + 1]
+        index += 1
+
+    raise AssertionError(f"unclosed function: {name}")
+
+
 def main() -> int:
     root_cmake = read("CMakeLists.txt")
     desktop_cmake = read("apps/desktop/CMakeLists.txt")
@@ -28,6 +49,8 @@ def main() -> int:
     main_cpp = read("apps/desktop/src/main.cpp")
     shell_h = read("apps/desktop/src/DesktopShellController.h")
     shell_cpp = read("apps/desktop/src/DesktopShellController.cpp")
+    mac_behavior_h = read("apps/desktop/src/platform/MacPetWindowBehavior.h")
+    mac_behavior_mm = read("apps/desktop/src/platform/MacPetWindowBehavior.mm")
     surface_h = read("apps/desktop/src/pet/surface/PetSurfaceWindow.h")
     surface_cpp = read("apps/desktop/src/pet/surface/PetSurfaceWindow.cpp")
     visible_bounds_h = read("apps/desktop/src/pet/surface/PetVisibleBounds.h")
@@ -39,6 +62,7 @@ def main() -> int:
     bubble_qml = read("apps/desktop/qml/ChatBubbleWindow.qml")
     placement_cpp = read("apps/desktop/src/chat/ChatBubblePlacement.cpp")
     placement_smoke = read("apps/desktop/tests/chat_bubble_placement_smoke.cpp")
+    companion_show_body = extract_function(mac_behavior_mm, "prepareMacCompanionWindowForShow")
 
     require(
         "check_phase_2_4_chat_compact_bubble" in root_cmake,
@@ -119,6 +143,7 @@ def main() -> int:
         "Q_PROPERTY(int petScreenAvailableHeight READ petScreenAvailableHeight NOTIFY petWindowGeometryChanged)",
         "Q_PROPERTY(bool chatWindowExpanded READ chatWindowExpanded NOTIFY chatWindowStateChanged)",
         "Q_INVOKABLE QVariantMap placeChatBubble(int bubbleWidth, int bubbleHeight, int margin) const;",
+        "Q_INVOKABLE void prepareChatBubbleWindowForShow();",
         "void petWindowGeometryChanged();",
         "void chatWindowStateChanged();",
     ]:
@@ -134,8 +159,19 @@ def main() -> int:
         "emit chatWindowStateChanged();",
         "const ChatBubblePlacementResult placement = ::placeChatBubble(",
         "result.insert(QStringLiteral(\"pointer\"), placement.pointer);",
+        "void DesktopShellController::prepareChatBubbleWindowForShow()",
+        "prepareMacCompanionWindowForShow(m_chatBubbleWindow);",
     ]:
         require(token in shell_cpp, f"DesktopShellController.cpp missing {token}")
+    require("prepareMacCompanionWindowForShow(QWindow *window)" in mac_behavior_h + mac_behavior_mm,
+            "macOS companion bubble show behavior missing prepareMacCompanionWindowForShow")
+    for token in ["applyMacCompanionWindowBehavior(window);", "[nativeWindow orderFrontRegardless];"]:
+        require(token in companion_show_body,
+                f"macOS companion bubble show behavior missing {token}")
+    require(
+        "makeKeyAndOrderFront" not in companion_show_body,
+        "bubble companion show path should re-apply and order front without stealing key focus",
+    )
 
     for token in [
         "PetVisibleBounds.cpp",
@@ -296,6 +332,7 @@ def main() -> int:
         "function syncAssistantBubble()",
         "function updatePlacement()",
         "App.DesktopShell.placeChatBubble(width, height, bubbleMargin)",
+        "App.DesktopShell.prepareChatBubbleWindowForShow()",
         "property string pointerPlacement",
         "App.DesktopShell.chatWindowExpanded",
         "function hideForExpandedChat()",


### PR DESCRIPTION
## 变更

- 为聊天窗和回复气泡补齐 macOS companion window 行为，让它们跟随桌宠进入所有 Space / 全屏辅助层级。
- 移除聊天窗显隐时切换应用 Dock / activation policy 的链路，避免从全屏桌面空间跳回原桌面。
- 更新 macOS 窗口策略回归检查和相关文档，防止后续重新引入同类问题。

## 根因

聊天窗 `show()` / `hide()` 会通过 `setChatWindowDockVisible()` 切换 `NSApplicationActivationPolicy`。在 macOS 全屏 Space 中，这会把桌宠触发的聊天操作带回应用原本所在的桌面空间；关闭聊天窗时反向切换 policy 也会触发同类跳转。

## 验证

- `python3 tests/check_macos_window_behavior.py`
- `python3 tests/check_phase_2_0_ai_chat_mvp.py`
- `python3 tests/check_phase_2_4_chat_compact_bubble.py`
- `cmake --build build --target MilesEdgeworthDesktop`
- `ctest --test-dir build --output-on-failure`
- `git diff --check`