### PR TITLE
fix: 保留助手历史中的表达标记

### DIFF
--- a/apps/agent-core/internal/api/server.go
+++ b/apps/agent-core/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"milesedgeworth/agent-core/internal/chat"
+	"milesedgeworth/agent-core/internal/chat/expression"
 	chatservice "milesedgeworth/agent-core/internal/chat/service"
 	"milesedgeworth/agent-core/internal/store"
 )
@@ -210,13 +211,18 @@ func (s *Server) handleChatMessages(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
-	var reply strings.Builder
+	var displayReply strings.Builder
+	var rawReply strings.Builder
 	partialPersisted := false
 	persistPartialOnce := func(providerError bool) {
 		if partialPersisted {
 			return
 		}
-		if s.persistPartialReply(req.ConversationID, reply.String(), providerError) {
+		displayContent := displayReply.String()
+		if providerError || displayContent == "" {
+			return
+		}
+		if s.persistPartialReply(req.ConversationID, replyContent(rawReply.String(), displayContent), providerError) {
 			partialPersisted = true
 		}
 	}
@@ -247,9 +253,26 @@ func (s *Server) handleChatMessages(w http.ResponseWriter, r *http.Request) {
 
 	finished := false
 	providerError := false
+	pendingRawCoverage := ""
+	coverageParser := expression.NewParser(nil, "neutral", func(text string) {
+		pendingRawCoverage += text
+	}, func(string) {})
 	for event := range events {
+		if event.RawDelta != "" {
+			rawReply.WriteString(event.RawDelta)
+			coverageParser.Feed(event.RawDelta)
+		}
 		if event.Type == "TEXT_MESSAGE_CONTENT" {
-			reply.WriteString(event.Delta)
+			displayReply.WriteString(event.Delta)
+			if event.RawDelta == "" && !strings.HasPrefix(pendingRawCoverage, event.Delta) {
+				coverageParser.Flush()
+			}
+			if strings.HasPrefix(pendingRawCoverage, event.Delta) {
+				pendingRawCoverage = strings.TrimPrefix(pendingRawCoverage, event.Delta)
+			} else if event.RawDelta == "" {
+				rawReply.WriteString(event.Delta)
+				pendingRawCoverage = ""
+			}
 		}
 		if event.Type == "RUN_ERROR" {
 			providerError = true
@@ -263,12 +286,12 @@ func (s *Server) handleChatMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	content := reply.String()
-	if providerError || content == "" {
+	displayContent := displayReply.String()
+	if providerError || displayContent == "" {
 		return
 	}
 	if finished && ctx.Err() == nil {
-		_, _ = s.store.AppendMessage(req.ConversationID, store.RoleAssistant, content, false)
+		_, _ = s.store.AppendMessage(req.ConversationID, store.RoleAssistant, replyContent(rawReply.String(), displayContent), false)
 		return
 	}
 	persistPartialOnce(false)
@@ -300,6 +323,13 @@ func (s *Server) persistPartialReply(conversationID, content string, providerErr
 	}
 	_, err := s.store.AppendMessage(conversationID, store.RoleAssistant, content, true)
 	return err == nil
+}
+
+func replyContent(rawContent, displayContent string) string {
+	if rawContent != "" {
+		return rawContent
+	}
+	return displayContent
 }
 
 func writeStoreError(w http.ResponseWriter, err error) {
@@ -356,10 +386,27 @@ func messageResponses(messages []store.Message) []messageResponse {
 		responses = append(responses, messageResponse{
 			ID:        msg.ID,
 			Role:      msg.Role,
-			Content:   msg.Content,
+			Content:   responseContent(msg),
 			IsPartial: msg.IsPartial,
 			CreatedAt: msg.CreatedAt,
 		})
 	}
 	return responses
+}
+
+func responseContent(msg store.Message) string {
+	if msg.Role != store.RoleAssistant {
+		return msg.Content
+	}
+	return stripExpressionMarkers(msg.Content)
+}
+
+func stripExpressionMarkers(content string) string {
+	var out strings.Builder
+	parser := expression.NewParser(nil, "neutral", func(text string) {
+		out.WriteString(text)
+	}, func(string) {})
+	parser.Feed(content)
+	parser.Flush()
+	return out.String()
 }

--- a/apps/agent-core/internal/api/server_test.go
+++ b/apps/agent-core/internal/api/server_test.go
@@ -178,6 +178,290 @@ func TestChatPersistsUserAndAssistant(t *testing.T) {
 	}
 }
 
+func TestChatPersistsRawAssistantReplyButStreamsCleanText(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "[EXPR:objection]",
+				Value:    map[string]any{"state": "speaking", "expression": "objection"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "异议あり。",
+				RawDelta:  "异议あり。",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	events := readSSEEvents(t, resp.Body)
+	seenCleanDelta := false
+	for _, event := range events {
+		if strings.Contains(event.Delta, "[EXPR:") {
+			t.Fatalf("SSE delta leaked expression marker: %+v", event)
+		}
+		if event.Type == "TEXT_MESSAGE_CONTENT" && event.Delta == "异议あり。" {
+			seenCleanDelta = true
+		}
+	}
+	if !seenCleanDelta {
+		t.Fatalf("events = %+v, want clean text delta", events)
+	}
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "[EXPR:objection]异议あり。" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want raw expression reply", messages[1])
+	}
+}
+
+func TestChatPersistsFallbackExpressionRawTextOnce(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "没有标签的回复。",
+				Value:    map[string]any{"state": "speaking", "expression": "neutral"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "没有标签的回复。",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	_ = readSSEEvents(t, resp.Body)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "没有标签的回复。" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want raw text once", messages[1])
+	}
+}
+
+func TestChatPersistsMarkerAndTextRawChunkOnce(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "[EXPR:polite]好的。",
+				Value:    map[string]any{"state": "speaking", "expression": "polite"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "好的。",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	_ = readSSEEvents(t, resp.Body)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "[EXPR:polite]好的。" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want marker and text raw chunk once", messages[1])
+	}
+}
+
+func TestChatPersistsSplitRawChunkTextOnce(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "第一段",
+				RawDelta:  "第一段[EXPR:polite]第二段",
+			}
+			events <- chat.StreamEvent{
+				Type:  "CUSTOM",
+				Name:  "miles.pet.expression.requested",
+				RunID: params.RunID,
+				Value: map[string]any{"state": "speaking", "expression": "polite"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "第二段",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	_ = readSSEEvents(t, resp.Body)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "第一段[EXPR:polite]第二段" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want split raw chunk once", messages[1])
+	}
+}
+
+func TestChatPersistsSplitMarkerRawChunksOnce(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "第一段",
+				RawDelta:  "第一段[EX",
+			}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "PR:polite]第二段",
+				Value:    map[string]any{"state": "speaking", "expression": "polite"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "第二段",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	_ = readSSEEvents(t, resp.Body)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "第一段[EXPR:polite]第二段" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want split marker raw chunks once", messages[1])
+	}
+}
+
+func TestChatPersistsIncompleteMarkerTailOnce(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "第一段",
+				RawDelta:  "第一段[EX",
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "[EX",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	_ = readSSEEvents(t, resp.Body)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "第一段[EX" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want incomplete marker tail once", messages[1])
+	}
+}
+
 func TestChatRejectsUnknownConversation(t *testing.T) {
 	provider := &fakeProvider{}
 	_, server := newTestServer(t, provider, 8192)
@@ -223,6 +507,40 @@ func TestGetConversationMessagesIncludesPartialFlag(t *testing.T) {
 	}
 	if !messages[1].IsPartial {
 		t.Fatalf("reply isPartial = false, want true")
+	}
+}
+
+func TestGetConversationMessagesStripsExpressionTagsForAssistantContent(t *testing.T) {
+	st, server := newTestServer(t, &fakeProvider{}, 8192)
+	conv := createConversation(t, st)
+	if _, err := st.AppendMessage(conv.ID, store.RoleUser, "検事", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AppendMessage(conv.ID, store.RoleAssistant, "[EXPR:objection]异议あり。[EXPR:polite]失礼。", false); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(server.URL + "/v1/conversations/" + conv.ID + "/messages")
+	if err != nil {
+		t.Fatalf("GET messages: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var messages []store.Message
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(messages))
+	}
+	if messages[0].Content != "検事" {
+		t.Fatalf("user content = %q, want unchanged text", messages[0].Content)
+	}
+	if messages[1].Content != "异议あり。失礼。" {
+		t.Fatalf("assistant content = %q, want clean display text", messages[1].Content)
 	}
 }
 
@@ -309,6 +627,51 @@ func TestChatPersistsPartialOnceOnFlushError(t *testing.T) {
 	}
 	if messages[1].Role != store.RoleAssistant || messages[1].Content != "途中" || !messages[1].IsPartial {
 		t.Fatalf("partial message = %+v", messages[1])
+	}
+}
+
+func TestChatPersistsRawPartialOnFlushError(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 4)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "[EXPR:objection]",
+				Value:    map[string]any{"state": "speaking", "expression": "objection"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "途中",
+				RawDelta:  "途中",
+			}
+			close(events)
+			return events, nil
+		},
+	}
+	st, handler := newTestHandler(t, provider, 8192)
+	conv := createConversation(t, st)
+	body := strings.NewReader(fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/messages", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := &flushErrorRecorder{
+		header:      make(http.Header),
+		failAtFlush: 3,
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "[EXPR:objection]途中" || !messages[1].IsPartial {
+		t.Fatalf("partial message = %+v, want raw expression partial", messages[1])
 	}
 }
 

--- a/apps/agent-core/internal/chat/service/service_test.go
+++ b/apps/agent-core/internal/chat/service/service_test.go
@@ -133,6 +133,35 @@ func TestBuildMessagesPutsPersonaBeforeExpressionRules(t *testing.T) {
 	}
 }
 
+func TestBuildMessagesKeepsAssistantExpressionMarkers(t *testing.T) {
+	s := openTestStore(t)
+	conv, err := s.CreateConversation("miles-edgeworth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendMessage(t, s, conv.ID, store.RoleUser, "前の推論を覚えているか。")
+	appendMessage(t, s, conv.ID, store.RoleAssistant, "[EXPR:objection]その推論には穴がある。")
+	appendMessage(t, s, conv.ID, store.RoleUser, "続けて。")
+
+	messages, _, err := newTestService(s, &fakeProvider{}, 8192).BuildMessages(context.Background(), BuildRequest{
+		ConversationID: conv.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var assistantContent string
+	for _, msg := range messages {
+		if msg.Role == store.RoleAssistant {
+			assistantContent = msg.Content
+			break
+		}
+	}
+	if assistantContent != "[EXPR:objection]その推論には穴がある。" {
+		t.Fatalf("assistant content = %q, want raw expression history", assistantContent)
+	}
+}
+
 func TestBuildMessagesExpressionRulesPreferDescription(t *testing.T) {
 	s := openTestStore(t)
 	conv, err := s.CreateConversation("miles-edgeworth")

--- a/docs/superpowers/plans/2026-05-27-chat-expression-history-raw-storage.md
+++ b/docs/superpowers/plans/2026-05-27-chat-expression-history-raw-storage.md
@@ -1,0 +1,735 @@
+# Chat Expression History Raw Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve `[EXPR:x]` markers in assistant history sent back to the model while keeping all chat-window display text marker-free.
+
+**Architecture:** Keep provider parsing unchanged: `StreamEvent.Delta` remains the clean UI text and `StreamEvent.RawDelta` remains the provider-origin content used for persistence and tracing. The API layer owns the boundary between model context and UI display: it stores assistant replies from raw stream content, passes stored raw assistant history to `ChatService`, and strips markers only when serving `/v1/conversations/{id}/messages` for UI restoration.
+
+**Tech Stack:** Go 1.22, `net/http`, existing `internal/chat/expression` streaming parser, SQLite store package, Go `testing` and `httptest`.
+
+---
+
+## Scope Check
+
+This plan implements one focused behavior change in the Go sidecar API layer.
+
+Included:
+- Persist completed assistant replies using `StreamEvent.RawDelta` when available.
+- Persist partial assistant replies using the same raw-content path.
+- Keep SSE `TEXT_MESSAGE_CONTENT.delta` unchanged so live chat display remains clean.
+- Strip `[EXPR:x]` markers from assistant messages returned by `GET /v1/conversations/{id}/messages`.
+- Keep `ChatService.BuildMessages()` unchanged so it reads raw assistant content directly from SQLite.
+- Verify README does not need a user-facing update.
+
+Excluded:
+- No Qt / QML changes.
+- No provider parser changes.
+- No schema migration.
+- No summary prompt behavior changes.
+- No historical data migration for existing clean assistant rows.
+
+## Design Context
+
+Read these before editing:
+
+- `docs/v2/设计方案/AI 聊天动画编排设计.md`
+  - `TEXT_MESSAGE_CONTENT` is a UI display event.
+  - `[EXPR:x]` markers do not enter `TEXT_MESSAGE_CONTENT`.
+- `docs/v2/设计方案/会话历史与人设设计.md`
+  - `messages.content` is model-context content, not necessarily UI text.
+  - `assistant` rows store raw provider replies with `[EXPR:x]`.
+  - `GET /v1/conversations/{id}/messages` returns clean assistant text for UI restoration.
+
+## File Structure
+
+Modify:
+
+- `apps/agent-core/internal/api/server.go`
+  - Owns chat HTTP/SSE handling and conversation message responses.
+  - Add raw/display reply accumulation in `handleChatMessages`.
+  - Add helper functions that choose persisted reply content and strip assistant display markers.
+
+- `apps/agent-core/internal/api/server_test.go`
+  - Add API tests for raw assistant persistence, clean SSE deltas, clean history restore, and raw partial persistence.
+  - Existing fake provider can emit `RawDelta` directly; no new test helper file is needed.
+
+No changes:
+
+- `apps/agent-core/internal/chat/openai/provider.go`
+  - It already emits `RawDelta` for raw model tokens.
+- `apps/agent-core/internal/chat/service/service.go`
+  - It already reads SQLite rows and passes `row.Content` to model messages.
+- `apps/agent-core/internal/store/store.go`
+  - Existing schema can store raw content without migration.
+- `apps/desktop/**`
+  - UI already consumes clean `Delta` live and `content` from message restore.
+
+## Task 0: Preflight
+
+**Files:**
+- Read: `docs/v2/设计方案/AI 聊天动画编排设计.md`
+- Read: `docs/v2/设计方案/会话历史与人设设计.md`
+- Read: `apps/agent-core/internal/api/server.go`
+- Read: `apps/agent-core/internal/api/server_test.go`
+
+- [ ] **Step 1: Confirm worktree and scope**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected:
+
+```text
+## feature/chat-expression-history...origin/main
+ M "docs/v2/设计方案/AI 聊天动画编排设计.md"
+ M "docs/v2/设计方案/会话历史与人设设计.md"
+```
+
+If additional files are modified, inspect them with `git diff -- <path>` before continuing. Do not overwrite unrelated work.
+
+- [ ] **Step 2: Run sidecar baseline tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Working directory:
+
+```text
+apps/agent-core
+```
+
+Expected: all packages pass.
+
+- [ ] **Step 3: Confirm implementation target**
+
+Run:
+
+```bash
+rg -n "RawDelta|var reply strings.Builder|messageResponses|persistPartialReply" apps/agent-core/internal/api apps/agent-core/internal/chat
+```
+
+Expected output includes:
+
+```text
+apps/agent-core/internal/chat/provider.go:40:	RawDelta  string         `json:"-"`
+apps/agent-core/internal/api/server.go:210:	var reply strings.Builder
+apps/agent-core/internal/api/server.go:297:func (s *Server) persistPartialReply
+apps/agent-core/internal/api/server.go:353:func messageResponses
+```
+
+## Task 1: API Red Tests For Completed Replies And History Restore
+
+**Files:**
+- Modify: `apps/agent-core/internal/api/server_test.go`
+
+- [ ] **Step 1: Add failing tests for completed assistant replies and restored history**
+
+Insert these tests after `TestChatPersistsUserAndAssistant` and after `TestGetConversationMessagesIncludesPartialFlag`, respectively:
+
+```go
+func TestChatPersistsRawAssistantReplyButStreamsCleanText(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 8)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "[EXPR:objection]",
+				Value:    map[string]any{"state": "speaking", "expression": "objection"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "异议あり。",
+				RawDelta:  "异议あり。",
+			}
+			events <- chat.StreamEvent{Type: "RUN_FINISHED", RunID: params.RunID}
+			close(events)
+			return events, nil
+		},
+	}
+	st, server := newTestServer(t, provider, 8192)
+	conv := createConversation(t, st)
+
+	resp := postChat(t, server.URL, fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("chat status = %d, want 200", resp.StatusCode)
+	}
+	events := readSSEEvents(t, resp.Body)
+	seenCleanDelta := false
+	for _, event := range events {
+		if strings.Contains(event.Delta, "[EXPR:") {
+			t.Fatalf("SSE delta leaked expression marker: %+v", event)
+		}
+		if event.Type == "TEXT_MESSAGE_CONTENT" && event.Delta == "异议あり。" {
+			seenCleanDelta = true
+		}
+	}
+	if !seenCleanDelta {
+		t.Fatalf("events = %+v, want clean text delta", events)
+	}
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "[EXPR:objection]异议あり。" || messages[1].IsPartial {
+		t.Fatalf("stored assistant message = %+v, want raw expression reply", messages[1])
+	}
+}
+```
+
+```go
+func TestGetConversationMessagesStripsExpressionTagsForAssistantContent(t *testing.T) {
+	st, server := newTestServer(t, &fakeProvider{}, 8192)
+	conv := createConversation(t, st)
+	if _, err := st.AppendMessage(conv.ID, store.RoleUser, "検事", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AppendMessage(conv.ID, store.RoleAssistant, "[EXPR:objection]异议あり。[EXPR:polite]失礼。", false); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(server.URL + "/v1/conversations/" + conv.ID + "/messages")
+	if err != nil {
+		t.Fatalf("GET messages: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var messages []store.Message
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(messages))
+	}
+	if messages[0].Content != "検事" {
+		t.Fatalf("user content = %q, want unchanged text", messages[0].Content)
+	}
+	if messages[1].Content != "异议あり。失礼。" {
+		t.Fatalf("assistant content = %q, want clean display text", messages[1].Content)
+	}
+}
+```
+
+- [ ] **Step 2: Format tests**
+
+Run:
+
+```bash
+gofmt -w apps/agent-core/internal/api/server_test.go
+```
+
+- [ ] **Step 3: Run tests and verify they fail for the intended reasons**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestChatPersistsRawAssistantReplyButStreamsCleanText|TestGetConversationMessagesStripsExpressionTagsForAssistantContent'
+```
+
+Working directory:
+
+```text
+apps/agent-core
+```
+
+Expected: both tests fail.
+
+Expected failure details:
+
+```text
+Content:异议あり。
+want raw expression reply
+assistant content = "[EXPR:objection]异议あり。[EXPR:polite]失礼。", want clean display text
+```
+
+## Task 2: Implement Raw Persistence And Clean Message Restore
+
+**Files:**
+- Modify: `apps/agent-core/internal/api/server.go`
+- Modify: `apps/agent-core/internal/api/server_test.go`
+
+- [ ] **Step 1: Import the expression parser**
+
+In `apps/agent-core/internal/api/server.go`, add the parser import beside the existing chat import:
+
+```go
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"milesedgeworth/agent-core/internal/chat"
+	"milesedgeworth/agent-core/internal/chat/expression"
+	chatservice "milesedgeworth/agent-core/internal/chat/service"
+	"milesedgeworth/agent-core/internal/store"
+)
+```
+
+- [ ] **Step 2: Replace the single reply builder with display and raw builders**
+
+In `handleChatMessages`, replace:
+
+```go
+	var reply strings.Builder
+	partialPersisted := false
+	persistPartialOnce := func(providerError bool) {
+		if partialPersisted {
+			return
+		}
+		if s.persistPartialReply(req.ConversationID, reply.String(), providerError) {
+			partialPersisted = true
+		}
+	}
+```
+
+with:
+
+```go
+	var displayReply strings.Builder
+	var rawReply strings.Builder
+	partialPersisted := false
+	persistPartialOnce := func(providerError bool) {
+		if partialPersisted || providerError || displayReply.String() == "" {
+			return
+		}
+		if s.persistPartialReply(req.ConversationID, replyContent(rawReply.String(), displayReply.String()), false) {
+			partialPersisted = true
+		}
+	}
+```
+
+- [ ] **Step 3: Accumulate raw and display content from every stream event**
+
+In the `for event := range events` loop, replace:
+
+```go
+		if event.Type == "TEXT_MESSAGE_CONTENT" {
+			reply.WriteString(event.Delta)
+		}
+```
+
+with:
+
+```go
+		if event.RawDelta != "" {
+			rawReply.WriteString(event.RawDelta)
+		}
+		if event.Type == "TEXT_MESSAGE_CONTENT" {
+			displayReply.WriteString(event.Delta)
+			if event.RawDelta == "" {
+				rawReply.WriteString(event.Delta)
+			}
+		}
+```
+
+This preserves provider-origin marker chunks from `CUSTOM` expression events and falls back to clean text for providers that do not populate `RawDelta`.
+
+- [ ] **Step 4: Store raw content on normal completion**
+
+Replace:
+
+```go
+	content := reply.String()
+	if providerError || content == "" {
+		return
+	}
+	if finished && ctx.Err() == nil {
+		_, _ = s.store.AppendMessage(req.ConversationID, store.RoleAssistant, content, false)
+		return
+	}
+	persistPartialOnce(false)
+```
+
+with:
+
+```go
+	content := displayReply.String()
+	if providerError || content == "" {
+		return
+	}
+	if finished && ctx.Err() == nil {
+		_, _ = s.store.AppendMessage(req.ConversationID, store.RoleAssistant, replyContent(rawReply.String(), content), false)
+		return
+	}
+	persistPartialOnce(false)
+```
+
+- [ ] **Step 5: Add helpers for persisted content and UI response content**
+
+After `persistPartialReply`, add:
+
+```go
+func replyContent(rawContent, displayContent string) string {
+	if rawContent != "" {
+		return rawContent
+	}
+	return displayContent
+}
+```
+
+Replace the `Content` assignment inside `messageResponses`:
+
+```go
+			Content:   msg.Content,
+```
+
+with:
+
+```go
+			Content:   responseContent(msg),
+```
+
+After `messageResponses`, add:
+
+```go
+func responseContent(msg store.Message) string {
+	if msg.Role != store.RoleAssistant {
+		return msg.Content
+	}
+	return stripExpressionMarkers(msg.Content)
+}
+
+func stripExpressionMarkers(content string) string {
+	var out strings.Builder
+	parser := expression.NewParser(nil, "neutral", func(text string) {
+		out.WriteString(text)
+	}, func(string) {})
+	parser.Feed(content)
+	parser.Flush()
+	return out.String()
+}
+```
+
+- [ ] **Step 6: Format implementation**
+
+Run:
+
+```bash
+gofmt -w apps/agent-core/internal/api/server.go apps/agent-core/internal/api/server_test.go
+```
+
+- [ ] **Step 7: Run the targeted tests**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestChatPersistsRawAssistantReplyButStreamsCleanText|TestGetConversationMessagesStripsExpressionTagsForAssistantContent'
+```
+
+Working directory:
+
+```text
+apps/agent-core
+```
+
+Expected:
+
+```text
+ok  	milesedgeworth/agent-core/internal/api
+```
+
+- [ ] **Step 8: Run the full API package**
+
+Run:
+
+```bash
+go test ./internal/api
+```
+
+Expected:
+
+```text
+ok  	milesedgeworth/agent-core/internal/api
+```
+
+## Task 3: Cover Raw Partial Persistence
+
+**Files:**
+- Modify: `apps/agent-core/internal/api/server_test.go`
+
+- [ ] **Step 1: Add a regression test for partial raw persistence**
+
+Insert this test after `TestChatPersistsPartialOnceOnFlushError`:
+
+```go
+func TestChatPersistsRawPartialOnFlushError(t *testing.T) {
+	provider := &fakeProvider{
+		streamFunc: func(ctx context.Context, params chat.ChatParams) (<-chan chat.StreamEvent, error) {
+			_ = ctx
+			events := make(chan chat.StreamEvent, 4)
+			events <- chat.StreamEvent{Type: "RUN_STARTED", RunID: params.RunID}
+			events <- chat.StreamEvent{
+				Type:     "CUSTOM",
+				Name:     "miles.pet.expression.requested",
+				RunID:    params.RunID,
+				RawDelta: "[EXPR:objection]",
+				Value:    map[string]any{"state": "speaking", "expression": "objection"},
+			}
+			events <- chat.StreamEvent{
+				Type:      "TEXT_MESSAGE_CONTENT",
+				RunID:     params.RunID,
+				MessageID: params.MessageID,
+				Delta:     "途中",
+				RawDelta:  "途中",
+			}
+			close(events)
+			return events, nil
+		},
+	}
+	st, handler := newTestHandler(t, provider, 8192)
+	conv := createConversation(t, st)
+	body := strings.NewReader(fmt.Sprintf(`{"conversationId":%q,"message":"hello"}`, conv.ID))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/messages", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := &flushErrorRecorder{
+		header:      make(http.Header),
+		failAtFlush: 3,
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	messages := getMessages(t, st, conv.ID)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2: %+v", len(messages), messages)
+	}
+	if messages[1].Role != store.RoleAssistant || messages[1].Content != "[EXPR:objection]途中" || !messages[1].IsPartial {
+		t.Fatalf("partial message = %+v, want raw expression partial", messages[1])
+	}
+}
+```
+
+- [ ] **Step 2: Format tests**
+
+Run:
+
+```bash
+gofmt -w apps/agent-core/internal/api/server_test.go
+```
+
+- [ ] **Step 3: Run the new partial test**
+
+Run:
+
+```bash
+go test ./internal/api -run TestChatPersistsRawPartialOnFlushError
+```
+
+Expected:
+
+```text
+ok  	milesedgeworth/agent-core/internal/api
+```
+
+- [ ] **Step 4: Run all persistence-related API tests**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestChatPersists|TestGetConversationMessages'
+```
+
+Expected:
+
+```text
+ok  	milesedgeworth/agent-core/internal/api
+```
+
+## Task 4: Verify ChatService Receives Raw Assistant History
+
+**Files:**
+- Modify: `apps/agent-core/internal/chat/service/service_test.go`
+
+- [ ] **Step 1: Add a focused ChatService regression test**
+
+Insert this test after `TestBuildMessagesPutsPersonaBeforeExpressionRules`:
+
+```go
+func TestBuildMessagesKeepsAssistantExpressionMarkers(t *testing.T) {
+	s := openTestStore(t)
+	conv, err := s.CreateConversation("miles-edgeworth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendMessage(t, s, conv.ID, store.RoleUser, "前の推論を覚えているか。")
+	appendMessage(t, s, conv.ID, store.RoleAssistant, "[EXPR:objection]その推論には穴がある。")
+	appendMessage(t, s, conv.ID, store.RoleUser, "続けて。")
+
+	messages, _, err := newTestService(s, &fakeProvider{}, 8192).BuildMessages(context.Background(), BuildRequest{
+		ConversationID: conv.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var assistantContent string
+	for _, msg := range messages {
+		if msg.Role == store.RoleAssistant {
+			assistantContent = msg.Content
+			break
+		}
+	}
+	if assistantContent != "[EXPR:objection]その推論には穴がある。" {
+		t.Fatalf("assistant content = %q, want raw expression history", assistantContent)
+	}
+}
+```
+
+- [ ] **Step 2: Format test file**
+
+Run:
+
+```bash
+gofmt -w apps/agent-core/internal/chat/service/service_test.go
+```
+
+- [ ] **Step 3: Run the ChatService test**
+
+Run:
+
+```bash
+go test ./internal/chat/service -run TestBuildMessagesKeepsAssistantExpressionMarkers
+```
+
+Expected:
+
+```text
+ok  	milesedgeworth/agent-core/internal/chat/service
+```
+
+This should pass without production-code changes because `ChatService` already uses `row.Content`.
+
+## Task 5: Full Verification And Documentation Check
+
+**Files:**
+- Read: `README.md`
+- Read: `docs/v2/设计方案/AI 聊天动画编排设计.md`
+- Read: `docs/v2/设计方案/会话历史与人设设计.md`
+- Modify only if verification exposes a design mismatch.
+
+- [ ] **Step 1: Run all Go tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Working directory:
+
+```text
+apps/agent-core
+```
+
+Expected: all packages pass.
+
+- [ ] **Step 2: Run relevant static contract checks**
+
+Run from repository root:
+
+```bash
+python3 tests/check_phase_2_1_provider.py
+python3 tests/check_phase_2_3_2_session_persona.py
+python3 tests/check_phase_2_4_phased_animation.py
+```
+
+Expected: all three scripts complete without `AssertionError`.
+
+- [ ] **Step 3: Check formatting and whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Check README impact**
+
+Run:
+
+```bash
+rg -n "chat|history|EXPR|conversation" README.md
+git diff -- README.md
+```
+
+Expected: `rg` may print existing README references, and `git diff -- README.md` prints no diff. No README update is needed because this change adjusts an internal persistence/display boundary rather than user-facing setup or usage.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- apps/agent-core/internal/api/server.go apps/agent-core/internal/api/server_test.go apps/agent-core/internal/chat/service/service_test.go
+git diff -- docs/v2/设计方案/AI\ 聊天动画编排设计.md docs/v2/设计方案/会话历史与人设设计.md
+```
+
+Expected:
+
+```text
+apps/agent-core/internal/api/server.go
+apps/agent-core/internal/api/server_test.go
+apps/agent-core/internal/chat/service/service_test.go
+docs/v2/设计方案/AI 聊天动画编排设计.md
+docs/v2/设计方案/会话历史与人设设计.md
+```
+
+The code diff must show:
+- Raw assistant persistence uses `RawDelta` when present.
+- SSE writing still serializes clean `Delta`; `RawDelta` is not exposed because it has `json:"-"`.
+- `messageResponses` strips expression markers only for assistant messages.
+- `ChatService` test confirms model context keeps assistant markers.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add apps/agent-core/internal/api/server.go apps/agent-core/internal/api/server_test.go apps/agent-core/internal/chat/service/service_test.go docs/v2/设计方案/AI\ 聊天动画编排设计.md docs/v2/设计方案/会话历史与人设设计.md
+git commit -m "fix: 保留助手历史中的表达标记"
+```
+
+Expected: commit succeeds on `feature/chat-expression-history`.
+
+## Self-Review
+
+Spec coverage:
+- Model history includes `[EXPR:x]`: Task 2 stores raw assistant replies and Task 4 verifies `ChatService` keeps markers.
+- Chat UI sees clean replies: Task 1 verifies SSE deltas are clean and restored history strips markers.
+- Partial replies follow the same storage semantics: Task 3 verifies raw partial persistence.
+- Design docs as long-term truth: Task 5 keeps the existing design-doc edits in the final diff and checks for mismatch.
+
+Placeholder scan:
+- The red-flag placeholder scan passed.
+- Each code-changing step includes exact Go code to insert or replace.
+- Each verification step includes exact commands and expected outcomes.
+
+Type consistency:
+- `chat.StreamEvent.RawDelta` matches `apps/agent-core/internal/chat/provider.go`.
+- `store.RoleAssistant` matches existing store role constants used by API and service tests.
+- `expression.NewParser(nil, "neutral", onText, onExpression)` matches the existing parser constructor.
+- `messageResponse.Content` remains the API field consumed by Qt.

--- a/docs/v2/设计方案/AI 聊天动画编排设计.md
+++ b/docs/v2/设计方案/AI 聊天动画编排设计.md
@@ -249,6 +249,7 @@ RUN_FINISHED
 
 - `expression.requested` 事件**永远**出现在它对应段的文字之前。
 - `[EXPR:x]` 标记本身不进入 `TEXT_MESSAGE_CONTENT`，Qt 侧看不到它。
+- `TEXT_MESSAGE_CONTENT` 是面向 UI 的展示文本事件，不定义会话持久化格式；持久化层保存包含 `[EXPR:x]` 的原始 assistant 回复供后续模型上下文使用。
 - `lifecycle` 事件不参与 segment queue，ChatController 直接处理。
 - 一次 RUN 中允许任意数量的 expression 切换。
 

--- a/docs/v2/设计方案/会话历史与人设设计.md
+++ b/docs/v2/设计方案/会话历史与人设设计.md
@@ -233,6 +233,7 @@ erDiagram
 - `conversations.title`：自动取第一条 user message 的前 30 字符，UI 显示用
 - `conversations.skin_id`：记录创建会话时的皮肤 id，仅用于信息展示
 - `messages.role = 'summary'`：摘要压缩后的消息，发送给模型时转换为 system 内容（见 §5.1）
+- `messages.content`：存储供模型上下文使用的规范内容，不等同于 UI 展示文本。`assistant` 消息保存 provider 原始回复，保留 `[EXPR:x]` 标记；`user` 消息保存用户发送的文本；`summary` 消息保存摘要文本，不包含 EXPR 协议标记
 - `messages.is_partial`：只有 `role='assistant'` 的消息可能为 1（用户取消/断连），`user` 和 `summary` 永远为 0
 - 时间戳用 ISO 8601 UTC 字符串，SQLite 没有原生时间类型
 
@@ -286,7 +287,7 @@ sidecar 新增以下端点供 Qt 调用：
 | GET | `/v1/conversations` | 列出所有会话，返回 `[{id, title, skinId, updatedAt}]`，按 `updatedAt DESC`，支持 `?limit=N`（默认 100） |
 | POST | `/v1/conversations` | 新建会话，body: `{"skinId":"..."}` |
 | DELETE | `/v1/conversations/{id}` | 删除指定会话及其所有消息 |
-| GET | `/v1/conversations/{id}/messages` | 获取指定会话的消息列表（UI 恢复用），返回 `[{id, role, content, isPartial, createdAt}]` |
+| GET | `/v1/conversations/{id}/messages` | 获取指定会话的消息列表（UI 恢复用），返回 `[{id, role, content, isPartial, createdAt}]`。返回给 UI 的 `assistant.content` 必须剥离 `[EXPR:x]` 标记，保证聊天窗只展示干净文本 |
 
 现有 `POST /v1/chat/messages` 保持不变，但 sidecar 内部逻辑变为：
 
@@ -294,7 +295,7 @@ sidecar 新增以下端点供 Qt 调用：
 2. 将 user message 存入 SQLite
 3. ChatService 组装完整 messages 数组（见 §5）
 4. 调 Provider 发送，流式返回 SSE events
-5. 流结束后将 assistant 完整回复存入 SQLite
+5. 流结束后将 assistant 原始回复存入 SQLite，保留 `[EXPR:x]` 标记；SSE `TEXT_MESSAGE_CONTENT` 仍只发送剥离标记后的展示文本
 
 ### 4.2 聊天请求时序
 
@@ -333,10 +334,10 @@ sequenceDiagram
 
 | 场景 | user message | assistant message |
 |------|-------------|-------------------|
-| 正常完成 | 已入库（发送前写入） | 流结束后写入完整回复 |
-| 用户取消 | 已入库 | 如果已收到部分内容，保存截断文本并标记 `is_partial=1`。UI 侧 Qt 已有 drain-after-cancel 语义，sidecar 对齐 |
+| 正常完成 | 已入库（发送前写入） | 流结束后写入包含 `[EXPR:x]` 标记的原始回复 |
+| 用户取消 | 已入库 | 如果已收到部分内容，保存包含 `[EXPR:x]` 标记的截断原始回复并标记 `is_partial=1`。UI 侧 Qt 已有 drain-after-cancel 语义，sidecar 对齐 |
 | Provider error | 已入库 | 不入库。UI 显示错误提示 |
-| 网络断开 | 已入库 | 同取消：保存已收到的 partial，标记 `is_partial=1` |
+| 网络断开 | 已入库 | 同取消：保存已收到的 partial 原始回复，标记 `is_partial=1` |
 
 原则：user message 始终保留（用户确实发了），assistant 只在有实际内容时保存。
 
@@ -400,11 +401,13 @@ ChatService 输出给 Provider 的 messages 数组结构：
 [
   {"role": "system", "content": "<persona>\n\n<EXPR rules>\n\n[如有摘要] 以下是较早对话的摘要：\n<summary>"},
   {"role": "user", "content": "旧消息1"},
-  {"role": "assistant", "content": "旧回复1"},
+  {"role": "assistant", "content": "[EXPR:objection]旧回复1"},
   ...
   {"role": "user", "content": "当前消息"}
 ]
 ```
+
+`assistant` 历史使用 SQLite 中保存的原始回复，保留 `[EXPR:x]` 标记。这样模型在后续请求中能看到过往回复的表达标记习惯；UI 恢复显示时的剥离逻辑不影响 ChatService 上下文。
 
 **摘要作为 system 内容**：DB 中 `role='summary'` 的记录在发送给模型时，转换为 system prompt 的一部分（追加在 EXPR 规则之后），前缀"以下是较早对话的摘要："。不使用 `role: assistant`，因为摘要不是模型真实说过的话，用 assistant 角色会污染角色输出。这一做法与 LibreChat（summary 转 `role: system`）和 lobe-chat（summary 注入 system 消息体内）的成熟实践一致。
 


### PR DESCRIPTION
## 变更内容

- 持久化 assistant 原始回复，保留 `[EXPR:x]` 标记供后续模型上下文使用
- 恢复历史消息接口仅对 assistant 展示内容剥离表达标记，聊天窗继续显示干净文本
- 补充 raw/display 双轨、partial、跨 chunk 和半截标记尾部等回归测试
- 更新 `docs/v2/设计方案/` 中关于会话持久化与 UI 展示边界的长期规则

## 原因

历史 assistant 回复如果只保存干净文本，模型在后续请求中看不到 `[EXPR:x]` 使用习惯，长对话里会逐渐减少表达标记。

## 验证

- `cd apps/agent-core && go test -count=1 ./...`
- `python3 tests/check_phase_2_1_provider.py && python3 tests/check_phase_2_3_2_session_persona.py && python3 tests/check_phase_2_4_phased_animation.py`
- `git diff --check`
- `cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=/opt/homebrew`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`